### PR TITLE
Adds requirement for USAGE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,21 +2,22 @@
 
 This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).
 
-**Value**
+### Value
 
 This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.
 
 - [ ] The blueprint applies to a focused use case.
 - [ ] The blueprint uses at least one XebiaLabs product.
-- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool, one specific Java EE application server and one specific ticketing system can only be used by users that have all three products.
+- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
 - [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.
 
-**Technical**
+### Technical
 
 This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.
 
 - [ ] The branch from which the PR is created is up-to-date with the `development` branch.
-- [ ] There is a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder. Also, the blueprint generates a `xebialabs/README.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
+- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder.
+- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
 - [ ] The blueprint generates a `docker/docker-compose.yml` file which can be used to spin up the required non-XebiaLabs products that the blueprints uses. This can be used to test and/or try out the blueprint without having to manually install those products.
 - [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
 - [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
@@ -24,8 +25,7 @@ This section describes how to determine whether the blueprint has the right tech
 - [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
 - [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`
 
-
-**Review and testing**
+### Review and testing
 
 This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.
 


### PR DESCRIPTION
* Splits requirement for two `README.md` files into two separate requirements: a `README.md` at the root of the blueprint and a generated `USAGE.md` in the `xebialabs` folder.
* Fixes some other typos.

