### PR TITLE
LOVE-777 Added app name on all resource names

### DIFF
--- a/aws/microservice-ecommerce/blueprint.yaml
+++ b/aws/microservice-ecommerce/blueprint.yaml
@@ -37,18 +37,19 @@ spec:
     type: Select
     description: "Select the AWS region:"
     options:
-      - eu-central-1
-      - eu-west-1
-      - eu-west-2
-      - eu-west-3
-      - eu-north-1
+    # This needs to be updated in the RegionMap of cloudformation/eks-workers.yaml as well
+      - us-west-2
       # commented out because of https://github.com/boto/boto3/issues/811
       # - us-east-1
       - us-east-2
-      - us-west-2
-      - ap-south-1
+      - eu-central-1
+      - eu-north-1
+      - eu-west-1
+      - eu-west-2
+      - eu-west-3
       - ap-northeast-1
       - ap-northeast-2
+      - ap-south-1
       - ap-southeast-1
       - ap-southeast-2
   - name: ProvisionCluster

--- a/aws/microservice-ecommerce/cloudformation/eks-master.yaml
+++ b/aws/microservice-ecommerce/cloudformation/eks-master.yaml
@@ -19,6 +19,7 @@ Resources:
     Description: Allows EKS to manage clusters on your behalf.
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub "${ProjectName}-ClusterRole"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -34,6 +35,7 @@ Resources:
   ClusterControlPlaneSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupName: !Sub "${ProjectName}-ClusterSecurityGroup"
       GroupDescription: Cluster communication with worker nodes
       VpcId:
         Fn::ImportValue:

--- a/aws/microservice-ecommerce/cloudformation/eks-user.yaml
+++ b/aws/microservice-ecommerce/cloudformation/eks-user.yaml
@@ -20,12 +20,13 @@ Resources:
     Type: AWS::IAM::User
     Properties:
       UserName: !Sub '${UserStackName}'
+
   LambdaPolicy:
     Type: AWS::IAM::Policy
     DependsOn:
       - LambdaRole
     Properties:
-      PolicyName: CFNCustomSecretProviderPolicy
+      PolicyName: !Sub "${ProjectName}-CFNCustomSecretProviderPolicy"
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -55,9 +56,11 @@ Resources:
             Effect: Allow
       Roles:
         - !Ref 'LambdaRole'
+
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub "${ProjectName}-LambdaRole"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -67,6 +70,7 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
+
   CFNSecretProvider:
     Type: AWS::Lambda::Function
     DependsOn:
@@ -76,7 +80,7 @@ Resources:
       Code:
         S3Bucket: !Ref 'S3BucketPrefix'
         S3Key: !Ref 'CFNCustomProviderZipFileName'
-      FunctionName: !Sub 'binxio-cfn-secret-provider-${UserStackName}'
+      FunctionName: !Sub '${ProjectName}-cfn-secret-provider-${UserStackName}'
       Handler: secrets.handler
       MemorySize: 128
       Timeout: 30
@@ -92,7 +96,7 @@ Resources:
       Name: !Sub '/${AWS::StackName}/demo/private-key'
       Version: v1
       NoEcho: False
-      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-secret-provider-${UserStackName}'
+      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${ProjectName}-cfn-secret-provider-${UserStackName}'
 
   KeyPair:
     Type: Custom::KeyPair
@@ -104,7 +108,7 @@ Resources:
       Name: !Ref EksUser
       NoEcho: False
       PublicKeyMaterial: !GetAtt 'PrivateKey.PublicKey'
-      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-secret-provider-${UserStackName}'
+      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${ProjectName}-cfn-secret-provider-${UserStackName}'
 
 Outputs:
   Username:

--- a/aws/microservice-ecommerce/cloudformation/eks-workers.yaml
+++ b/aws/microservice-ecommerce/cloudformation/eks-workers.yaml
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Amazon EKS - Workers for Microservices Application'
 
+Parameters:
+  ProjectName:
+    Type: String
+    Default: "app"
 
 Mappings:
     RegionMap:
@@ -116,15 +120,19 @@ Parameters:
     Default: app
 
 Resources:
+
   NodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
+      InstanceProfileName: !Sub "${ProjectName}-InstanceProfile"
       Path: "/"
       Roles:
       - !Ref NodeInstanceRole
+
   NodeInstanceRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub "${ProjectName}-NodeInstanceRole"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -139,9 +147,11 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+
   NodeSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupName: !Sub "${ProjectName}-NodeSecurityGroup"
       GroupDescription: Security group for all nodes in the cluster
       VpcId:
         Fn::ImportValue:
@@ -149,6 +159,7 @@ Resources:
       Tags:
       - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
         Value: 'owned'
+
   NodeSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -159,6 +170,7 @@ Resources:
       IpProtocol: '-1'
       FromPort: 0
       ToPort: 65535
+
   NodeSecurityGroupFromControlPlaneIngress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -171,6 +183,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 1025
       ToPort: 65535
+
   ControlPlaneEgressToNodeSecurityGroup:
     Type: AWS::EC2::SecurityGroupEgress
     DependsOn: NodeSecurityGroup
@@ -183,6 +196,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 1025
       ToPort: 65535
+
   NodeSecurityGroupFromControlPlaneOn443Ingress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -195,6 +209,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 443
       ToPort: 443
+
   ControlPlaneEgressToNodeSecurityGroupOn443:
     Type: AWS::EC2::SecurityGroupEgress
     DependsOn: NodeSecurityGroup
@@ -207,6 +222,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 443
       ToPort: 443
+
   ClusterControlPlaneSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -219,9 +235,11 @@ Resources:
       IpProtocol: tcp
       ToPort: 443
       FromPort: 443
+
   NodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
+      AutoScalingGroupName: !Sub "${ProjectName}-AutoScalingGroup"
       DesiredCapacity: !Ref NodeAutoScalingGroupMaxSize
       LaunchConfigurationName: !Ref NodeLaunchConfig
       MinSize: !Ref NodeAutoScalingGroupMinSize
@@ -242,9 +260,11 @@ Resources:
       AutoScalingRollingUpdate:
         MinInstancesInService: '1'
         MaxBatchSize: '1'
+
   NodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
+      LaunchConfigurationName: !Sub "${ProjectName}-LaunchConfiguration"
       AssociatePublicIpAddress: 'true'
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId: !FindInMap ["RegionMap", Ref: "AWS::Region", "AmiId"]

--- a/aws/microservice-ecommerce/cloudformation/eks-workers.yaml
+++ b/aws/microservice-ecommerce/cloudformation/eks-workers.yaml
@@ -9,13 +9,31 @@ Parameters:
 Mappings:
     RegionMap:
         us-west-2:
-            "AmiId": "ami-0f54a2f7d2e9c88b3"
+            "AmiId": "ami-05a71d034119ffc12"
         us-east-1:
-            "AmiId": "ami-0a0b913ef3249b655"
+            "AmiId": "ami-03a1e71fb42fc37dd"
         us-east-2:
-            "AmiId": "ami-0958a76db2d150238"
+            "AmiId": "ami-093d55c2ba99ab2c8"
+        eu-central-1:
+            "AmiId": "ami-03bdf8079f6c013c5"
+        eu-north-1:
+            "AmiId": "ami-0be77fe86d741fc81"
         eu-west-1:
-            "AmiId": "ami-00c3b2d35bddd4f5c"
+            "AmiId": "ami-06368da7f495b68e9"
+        eu-west-2:
+            "AmiId": "ami-0f1f2189b4741bc60"
+        eu-west-3:
+            "AmiId": "ami-03a9acb0f6e0d424d"
+        ap-northeast-1:
+            "AmiId": "ami-0c9fb6a3fda95d373"
+        ap-northeast-2:
+            "AmiId": "ami-00ea4ea959f28b4cf"
+        ap-south-1:
+            "AmiId": "ami-0f07478f5c5eb9e20"
+        ap-southeast-1:
+            "AmiId": "ami-05dac5d0ada75e22f"
+        ap-southeast-2:
+            "AmiId": "ami-00513f18e1900ce1e"
 
 Parameters:
   ProjectName:


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] The blueprint generates a `docker/docker-compose.yml` file which can be used to spin up the required non-XebiaLabs products that the blueprints uses. This can be used to test and/or try out the blueprint without having to manually install those products.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] The CI for the PR is green
- [x] The blueprint has been reviewed by someone else in the team.
- [x] Both README files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
