### PR TITLE
LOVE-137 - AKS blueprint

### DIFF
--- a/azure/microservice-ecommerce/README.md
+++ b/azure/microservice-ecommerce/README.md
@@ -1,0 +1,227 @@
+# Microservice Application on Google Kubernetes Engine
+
+## Introduction
+
+Azure Kubernetes Service (AKS) allows you to deploy, manage, and scale containerized applications in the cloud using Kubernetes.
+
+Use this blueprint to deploy a sample microservice-based application on AKS using Terraform, which defines the infrastructure that will run on AKS. The release template that the blueprint generates connects to an existing AKS cluster or provisions a new cluster and deploys a sample application to it.
+
+## Before you get started
+
+If you're new to XebiaLabs blueprints, check out:
+
+* [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
+* [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
+* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
+
+## Tools and technologies
+
+This blueprint includes the following tools and technologies:
+
+* Target:
+    * [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/services/kubernetes-service/)
+* Tools:
+    * [XebiaLabs Release Orchestration](https://xebialabs.com/products/xl-release/)
+    * [XebiaLabs Deployment Automation](https://xebialabs.com/products/xl-deploy/)
+    * [Jenkins](https://jenkins.io/)
+    * [Kubernetes](https://kubernetes.io/)
+    * [Terraform](https://www.terraform.io/)
+* Application or framework:
+    * [JHipster](https://github.com/xebialabs/e-commerce-microservice/)
+
+## Minimum Required versions
+
+This blueprint version requires at least the below versions of the specified tools to work properly.
+
+XL Release: Version 8.6
+XL Deploy: Version 8.6.1
+XL CLI: Version 8.6
+
+## Prerequisites
+
+To run the YAML that this blueprint generates, you need:
+
+* XebiaLabs Release Orchestration and Deployment Automation up and running
+* Access to an Azure account account to deploy the application to
+* A Jenkins server up and running (only if you want to publish your own Docker images)
+
+## Information required
+
+This blueprint requires:
+
+* Azure Service Principal (see section below for instructions)
+* Azure Resource Group (see section below for instructions)
+* An Azure region
+* The AKS cluster endpoint (if deploying to an existing cluster)
+* Azure Storage Account for the Terraform state if creating a new cluster (see section below for instructions)
+* Kubernetes cluster credentials
+* The Kubernetes namespace
+* Jenkins credentials (if enabling CI integration)
+
+## Steps
+
+### Step 1: Install the Azure CLI (`az`) binary
+
+> **Follow these instructions to install the Azure CLI on your platform:**
+>
+> * https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
+
+> **Note:** All examples below use the CLI
+
+### Step 2: Log into Azure
+
+```plain
+az login
+```
+
+Follow the prompts to log in
+
+> **Note:** You need to have proper permissions and privileges in the Azure account to execute these commands. If you are using a personal account you should be having these as you will be the admin. If you are using a company/enterprise account please check with your account administrator.
+
+### Step 3: Set up the environment
+
+> **Please take note of the following:**
+>
+> * You need an existing **Service Principal** in order for the blueprint to create resources
+> * You will need a **Resource Group** in order to create the **Storage Account** if you need to store Terraform state
+> * If you are creating a new Kubernetes cluster, the blueprint will create a **new Resource Group** to hold that cluster
+
+> **Important:** Running `terraform destroy` will completely remove the **new Resource Group** you specify in the blueprint (and all resources associated with it). So don't give the name of an existing Resource Group unless you're willing to lose it.
+
+#### 3.1 Create a Service Principal
+
+If you don't already have a Service Principal, create one using the GUI or the CLI:
+
+> **See:**
+>
+> * [**GUI:** How to: Use the portal to create an Azure AD application and service principal that can access resources](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
+> * [**CLI:** Create an Azure service principal with Azure CLI](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest)
+
+> **Note:** Regardless of how you create the Service Principal, take note of the `appId`, `password` and `tenant` id; you will be asked for it by the blueprint
+
+#### 3.2 Create a Resource Group for the Storage Account
+
+> **See:**
+>
+> * [**CLI:** az group create](https://docs.microsoft.com/en-us/cli/azure/group?view=azure-cli-latest#az-group-create)
+
+This will be the Resource Group for the Terraform state. It should **NOT** be the same as the Resource Group specified in the blueprint.
+
+Example:
+```plain
+az group create --name RESOURCE_GROUP \
+                --location LOCATION
+```
+
+#### 3.3 Create a Storage Account to store the Terraform state
+
+> **Note:** This step is only necessary if you want the blueprint to create the Kubernetes cluster for you
+
+If you don't already have a Storage account, create one using the GUI or the CLI:
+
+> **See:**
+>
+> * [**GUI:** Create a storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal)
+> * [**CLI:** Create a storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=azure-cli)
+> * [Documentation and syntax](https://docs.microsoft.com/en-us/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-create)
+
+Example:
+```plain
+az storage account create --name ACCOUNT_NAME \
+                          --resource-group EXISTING_RESOURCE_GROUP \
+                          --location LOCATION \
+                          --sku Standard_LRS \
+                          --subscription SUBSCRIPTION_ID
+```
+
+> **Note:** Make sure the `location` you choose for the Storage Account is the same as the one you will use in the blueprint and the one you used to create the Resource Group
+> **Note:** Take note of the name you give the Storage Account; you will be asked for it by the blueprint
+
+##### 3.3.1 Get the Storage account keys in order to create the Storage Container
+
+> **See:**
+>
+> * [CLI: az storage account keys](https://docs.microsoft.com/en-us/cli/azure/storage/account/keys?view=azure-cli-latest)
+
+Example
+```plain
+az storage account keys list --account-name ACCOUNT_NAME
+[
+  {
+    "keyName": "key1",
+    "permissions": "Full",
+    "value": "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmn=="
+  },
+  {
+    "keyName": "key2",
+    "permissions": "Full",
+    "value": "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmn=="
+  }
+]
+```
+
+> **Note:** Copy one of the key `value`s to use in creating the Storage Container
+
+##### 3.3.2 Create a Storage Container (if you don't already have one)
+
+> [**CLI:** azure storage container create](https://docs.microsoft.com/en-us/cli/azure/storage/container?view=azure-cli-latest#az-storage-container-create)
+
+Example:
+```plain
+az storage container create --name terraform-state \
+                            --account-key ACCOUNT_KEY \
+                            --account-name ACCOUNT_NAME
+```
+
+### Step 4: Clone the `e-commerce-microservice` repository
+
+#### 4.1 With Jenkins CI/CD
+If you plan to use the Jenkins CI/CD part of the blueprint, first fork the https://github.com/xebialabs/e-commerce-microservice.git repo.
+
+> **Note:** You will use your GitHub username as the `GITHUB_USER` environment variable when deploying in the next stage.
+
+Make sure you have cloned the https://github.com/$GITHUB_USER/e-commerce-microservice.git (`gke-blueprint` branch) by running:
+
+```plain
+git clone -b gke-blueprint https://github.com/$GITHUB_USER/e-commerce-microservice.git
+```
+
+#### 4.2 Without Jenkins CI/CD
+Make sure you have cloned the https://github.com/xebialabs/e-commerce-microservice.git (`gke-blueprint` branch) by running:
+
+```plain
+git clone -b gke-blueprint https://github.com/xebialabs/e-commerce-microservice.git
+```
+
+### Step 5: Run the blueprint
+
+Now `cd` into `e-commerce-microservice` and run `xl blueprint`, then select:
+
+```plain
+azure/microservice-ecommerce
+```
+
+#### 5.1 Output
+
+The blueprint will output:
+
+* Release templates
+* Terraform templates
+* Infrastructure:
+    * AKS cluster (master, nodes)
+    * Security infrastructure
+* A docker-compose setup for XL JetPack and Jenkins
+
+> **Note:** You will find more instructions in `xebialabs/USAGE.md` after you have run the blueprint
+
+## Notes
+
+* If you opt to use Jenkins in the release template that this blueprint generates, before you run the `xl apply` command, define a Jenkins server as a shared configuration in XL Release and put its name in the `xlr-pipeline-ci-cd.yaml` file. If you use the provided `docker-compose.yml` file this will be automatically setup for you.
+* The YAML that the blueprint generates includes optional steps to remove the application and deprovision the cluster.
+
+## Labels
+
+* Cloud
+* Microsoft
+* Kubernetes
+* Terraform

--- a/azure/microservice-ecommerce/README.md
+++ b/azure/microservice-ecommerce/README.md
@@ -130,11 +130,10 @@ Example:
 az storage account create --name ACCOUNT_NAME \
                           --resource-group EXISTING_RESOURCE_GROUP \
                           --location LOCATION \
-                          --sku Standard_LRS \
-                          --subscription SUBSCRIPTION_ID
+                          --sku Standard_LRS
 ```
 
-> **Note:** Make sure the `location` you choose for the Storage Account is the same as the one you will use in the blueprint and the one you used to create the Resource Group
+> **Note:** Make sure the `location` you choose for the Storage Account is the same as the one you will use in the blueprint and the one you used to create the Resource Group. Use the same Resource Group you created earlier to use for the blueprint.
 > **Note:** Take note of the name you give the Storage Account; you will be asked for it by the blueprint
 
 ##### 3.3.1 Get the Storage account keys in order to create the Storage Container
@@ -200,6 +199,11 @@ Now `cd` into `e-commerce-microservice` and run `xl blueprint`, then select:
 ```plain
 azure/microservice-ecommerce
 ```
+
+TODO: 
+Note about subscription ID
+Note about SSH key path
+Note about password token
 
 #### 5.1 Output
 

--- a/azure/microservice-ecommerce/README.md
+++ b/azure/microservice-ecommerce/README.md
@@ -97,7 +97,7 @@ If you don't already have a Service Principal, create one using the GUI or the C
 > * [**GUI:** How to: Use the portal to create an Azure AD application and service principal that can access resources](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
 > * [**CLI:** Create an Azure service principal with Azure CLI](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest)
 
-> **Note:** Regardless of how you create the Service Principal, take note of the `appId`, `password` and `tenant` id; you will be asked for it by the blueprint
+> **Note:** Regardless of how you create the Service Principal, take note of the fields `appId`, `password` and `tenant`; you will be asked for it by the blueprint
 
 #### 3.2 Create a Resource Group for the Storage Account
 

--- a/azure/microservice-ecommerce/__test__/answers-no-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-no-cluster-no-cicd.yaml
@@ -1,7 +1,5 @@
 AppName: azure-project
 ResourceGroup: azure-rg
-AdminUsername: adminuser
-AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-no-cluster-no-cicd.yaml
 AKSRegion: westeurope
 ProvisionCluster: false
 ClusterEndpoint: https://test.com

--- a/azure/microservice-ecommerce/__test__/answers-no-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-no-cluster-no-cicd.yaml
@@ -1,0 +1,20 @@
+AppName: azure-project
+ResourceGroup: azure-rg
+AdminUsername: adminuser
+AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-no-cluster-no-cicd.yaml
+AKSRegion: westeurope
+ProvisionCluster: false
+ClusterEndpoint: https://test.com
+PasswordToken: abcdefgh
+ClusterName: azure-cluster
+Namespace: xl-demo
+ClientID: A
+ClientSecret: B
+SubscriptionID: C
+TenantID: D
+enableCICD: false
+XLDUrlForXLR: http://xl-deploy:4516
+StorageAccountName: storageuser
+StorageContainerName: terraform-state
+StorageAccessKey: abcdefgh
+

--- a/azure/microservice-ecommerce/__test__/answers-no-cluster-with-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-no-cluster-with-cicd.yaml
@@ -1,0 +1,22 @@
+AppName: azure-project
+ResourceGroup: azure-rg
+AdminUsername: adminuser
+AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-no-cluster-with-cicd.yaml
+AKSRegion: westeurope
+ProvisionCluster: false
+ClusterEndpoint: https://test.com
+PasswordToken: abcdefgh
+ClusterName: azure-cluster
+Namespace: xl-demo
+ClientID: A
+ClientSecret: B
+SubscriptionID: C
+TenantID: D
+enableCICD: true
+StoreAdminUsername: admin
+StoreAdminPassword: admin
+XLDUrlForXLR: http://xl-deploy:4516
+StorageAccountName: storageuser
+StorageContainerName: terraform-state
+StorageAccessKey: abcdefgh
+

--- a/azure/microservice-ecommerce/__test__/answers-no-cluster-with-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-no-cluster-with-cicd.yaml
@@ -1,7 +1,5 @@
 AppName: azure-project
 ResourceGroup: azure-rg
-AdminUsername: adminuser
-AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-no-cluster-with-cicd.yaml
 AKSRegion: westeurope
 ProvisionCluster: false
 ClusterEndpoint: https://test.com

--- a/azure/microservice-ecommerce/__test__/answers-with-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-with-cluster-no-cicd.yaml
@@ -1,0 +1,18 @@
+AppName: azure-project
+ResourceGroup: azure-rg
+AdminUsername: adminuser
+AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-with-cluster-no-cicd.yaml
+AKSRegion: westeurope
+ProvisionCluster: true
+ClusterName: azure-cluster
+Namespace: xl-demo
+ClientID: A
+ClientSecret: B
+SubscriptionID: C
+TenantID: D
+enableCICD: false
+XLDUrlForXLR: http://xl-deploy:4516
+StorageAccountName: storageuser
+StorageContainerName: terraform-state
+StorageAccessKey: abcdefgh
+

--- a/azure/microservice-ecommerce/__test__/answers-with-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-with-cluster-no-cicd.yaml
@@ -1,7 +1,5 @@
 AppName: azure-project
 ResourceGroup: azure-rg
-AdminUsername: adminuser
-AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-with-cluster-no-cicd.yaml
 AKSRegion: westeurope
 ProvisionCluster: true
 ClusterName: azure-cluster

--- a/azure/microservice-ecommerce/__test__/answers-with-cluster-with-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-with-cluster-with-cicd.yaml
@@ -1,7 +1,5 @@
 AppName: azure-project
 ResourceGroup: azure-rg
-AdminUsername: adminuser
-AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-with-cluster-with-cicd.yaml
 AKSRegion: westeurope
 ProvisionCluster: true
 ClusterName: azure-cluster

--- a/azure/microservice-ecommerce/__test__/answers-with-cluster-with-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/answers-with-cluster-with-cicd.yaml
@@ -1,0 +1,20 @@
+AppName: azure-project
+ResourceGroup: azure-rg
+AdminUsername: adminuser
+AdminUsernameSSHKeyPath: ../azure/microservice-ecommerce/__test__/answers-with-cluster-with-cicd.yaml
+AKSRegion: westeurope
+ProvisionCluster: true
+ClusterName: azure-cluster
+Namespace: xl-demo
+ClientID: A
+ClientSecret: B
+SubscriptionID: C
+TenantID: D
+enableCICD: true
+StoreAdminUsername: admin
+StoreAdminPassword: admin
+XLDUrlForXLR: http://xl-deploy:4516
+StorageAccountName: storageuser
+StorageContainerName: terraform-state
+StorageAccessKey: abcdefgh
+

--- a/azure/microservice-ecommerce/__test__/test-no-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/test-no-cluster-no-cicd.yaml
@@ -12,8 +12,8 @@ expected-files:
     - xebialabs/xlr-pipeline-destroy.yaml
     - docker/docker-compose.yml
     - docker/data/configure-xl-devops-platform.yaml
-    - docker/jenkins/jenkins.yaml
 not-expected-files:
+    - docker/jenkins/jenkins.yaml
     - terraform/aks/main.tf
     - terraform/aks/outputs.tf
     - terraform/aks/variables.tf

--- a/azure/microservice-ecommerce/__test__/test-no-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/test-no-cluster-no-cicd.yaml
@@ -1,0 +1,24 @@
+# test the scenario with neither cluster nor CI-CD enabled
+answers-file: answers-no-cluster-no-cicd.yaml
+expected-files:
+    - xebialabs.yaml
+    - xebialabs/USAGE.md
+    - xebialabs/xld-infra-env.yaml
+    - xebialabs/xld-kubernetes-invoice-app.yaml
+    - xebialabs/xld-kubernetes-notification-app.yaml
+    - xebialabs/xld-kubernetes-store-app.yaml
+    - xebialabs/xld-terraform-apps.yaml
+    - xebialabs/xlr-pipeline-ci-cd.yaml
+    - xebialabs/xlr-pipeline-destroy.yaml
+    - docker/docker-compose.yml
+    - docker/data/configure-xl-devops-platform.yaml
+    - docker/jenkins/jenkins.yaml
+not-expected-files:
+    - terraform/aks/main.tf
+    - terraform/aks/outputs.tf
+    - terraform/aks/variables.tf
+    - terraform/.gitignore
+    - terraform/backend.tf
+    - terraform/main.tf
+    - terraform/outputs.tf
+    - terraform/variables.tf

--- a/azure/microservice-ecommerce/__test__/test-no-cluster-with-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/test-no-cluster-with-cicd.yaml
@@ -1,0 +1,24 @@
+# test the scenario with neither cluster nor CI-CD enabled
+answers-file: answers-no-cluster-with-cicd.yaml
+expected-files:
+    - xebialabs.yaml
+    - xebialabs/USAGE.md
+    - xebialabs/xld-infra-env.yaml
+    - xebialabs/xld-kubernetes-invoice-app.yaml
+    - xebialabs/xld-kubernetes-notification-app.yaml
+    - xebialabs/xld-kubernetes-store-app.yaml
+    - xebialabs/xld-terraform-apps.yaml
+    - xebialabs/xlr-pipeline-ci-cd.yaml
+    - xebialabs/xlr-pipeline-destroy.yaml
+    - docker/docker-compose.yml
+    - docker/data/configure-xl-devops-platform.yaml
+    - docker/jenkins/jenkins.yaml
+not-expected-files:
+    - terraform/aks/main.tf
+    - terraform/aks/outputs.tf
+    - terraform/aks/variables.tf
+    - terraform/.gitignore
+    - terraform/backend.tf
+    - terraform/main.tf
+    - terraform/outputs.tf
+    - terraform/variables.tf

--- a/azure/microservice-ecommerce/__test__/test-with-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/test-with-cluster-no-cicd.yaml
@@ -1,0 +1,23 @@
+# test the scenario with neither cluster nor CI-CD enabled
+answers-file: answers-with-cluster-no-cicd.yaml
+expected-files:
+    - xebialabs.yaml
+    - xebialabs/USAGE.md
+    - xebialabs/xld-infra-env.yaml
+    - xebialabs/xld-kubernetes-invoice-app.yaml
+    - xebialabs/xld-kubernetes-notification-app.yaml
+    - xebialabs/xld-kubernetes-store-app.yaml
+    - xebialabs/xld-terraform-apps.yaml
+    - xebialabs/xlr-pipeline-ci-cd.yaml
+    - xebialabs/xlr-pipeline-destroy.yaml
+    - docker/docker-compose.yml
+    - docker/data/configure-xl-devops-platform.yaml
+    - docker/jenkins/jenkins.yaml
+    - terraform/aks/main.tf
+    - terraform/aks/outputs.tf
+    - terraform/aks/variables.tf
+    - terraform/.gitignore
+    - terraform/backend.tf
+    - terraform/main.tf
+    - terraform/outputs.tf
+    - terraform/variables.tf

--- a/azure/microservice-ecommerce/__test__/test-with-cluster-no-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/test-with-cluster-no-cicd.yaml
@@ -12,7 +12,6 @@ expected-files:
     - xebialabs/xlr-pipeline-destroy.yaml
     - docker/docker-compose.yml
     - docker/data/configure-xl-devops-platform.yaml
-    - docker/jenkins/jenkins.yaml
     - terraform/aks/main.tf
     - terraform/aks/outputs.tf
     - terraform/aks/variables.tf
@@ -21,3 +20,5 @@ expected-files:
     - terraform/main.tf
     - terraform/outputs.tf
     - terraform/variables.tf
+not-expected-files:
+    - docker/jenkins/jenkins.yaml

--- a/azure/microservice-ecommerce/__test__/test-with-cluster-with-cicd.yaml
+++ b/azure/microservice-ecommerce/__test__/test-with-cluster-with-cicd.yaml
@@ -1,0 +1,23 @@
+# test the scenario with neither cluster nor CI-CD enabled
+answers-file: answers-with-cluster-with-cicd.yaml
+expected-files:
+    - xebialabs.yaml
+    - xebialabs/USAGE.md
+    - xebialabs/xld-infra-env.yaml
+    - xebialabs/xld-kubernetes-invoice-app.yaml
+    - xebialabs/xld-kubernetes-notification-app.yaml
+    - xebialabs/xld-kubernetes-store-app.yaml
+    - xebialabs/xld-terraform-apps.yaml
+    - xebialabs/xlr-pipeline-ci-cd.yaml
+    - xebialabs/xlr-pipeline-destroy.yaml
+    - docker/docker-compose.yml
+    - docker/data/configure-xl-devops-platform.yaml
+    - docker/jenkins/jenkins.yaml
+    - terraform/aks/main.tf
+    - terraform/aks/outputs.tf
+    - terraform/aks/variables.tf
+    - terraform/.gitignore
+    - terraform/backend.tf
+    - terraform/main.tf
+    - terraform/outputs.tf
+    - terraform/variables.tf

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -14,27 +14,34 @@ spec:
   parameters:
   - name: AppName
     type: Input
-    description: What do you want to name the application in XLD/XLR?
+    description: What do you want to name the application?
 
-  - name: ResourceGroup
-    # Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period
+  - name: ProvisionCluster
+    type: Confirm
+    description: Do you want to provision a new Azure AKS cluster?
+
+  # ############################################################################
+  # Own cluster
+  # ############################################################################
+  - name: ClusterEndpoint
     type: Input
-    description: "What do you want to name the Resource Group in Azure (Note: can be DESTROYED by Terraform at a later stage)?"
-    pattern: "^[\\w._()-]{2,50}[\\w_()-]$"
+    description: What is the endpoint for the existing cluster, example https://104.155.109.230
+    dependsOnTrue: !expression "!ProvisionCluster"
 
-  - name: AdminUsername
-    # Cannot be 'admin'
+  - name: PasswordToken
     type: Input
-    description: What username do you want to use to access the cluster (cannot be 'admin')?
-    pattern: "^[[:alpha:]]+$"
+    description: What is the token for accessing the existing cluster
+    dependsOnTrue: !expression "!ProvisionCluster"
+    secret: true
+  # ############################################################################
 
-  - name: AdminUsernameSSHKeyPath
-    type: File
-    description: What is the path to the public SSH key for the above user?
-
+  # ############################################################################
+  # New cluster
+  # ############################################################################
   - name: AKSRegion
     type: Select
-    description: "Select the AKS region:"
+    description: "Select the AKS region for the cluster:"
+    dependsOnTrue: ProvisionCluster
     options:
     - eastasia
     - southeastasia
@@ -69,49 +76,71 @@ spec:
     - southafricanorth
     - southafricawest
 
-  - name: ProvisionCluster
-    type: Confirm
-    description: Do you want to provision a new Azure AKS cluster?
-
-  - name: ClusterEndpoint
+    # ############################################################################
+  # Authentication
+  # ############################################################################
+  - name: SubscriptionID
     type: Input
-    description: What is the endpoint for the cluster, example https://104.155.109.230
-    dependsOnTrue: !expression "!ProvisionCluster"
+    description: "Enter you Azure subscription id:"
+    dependsOnTrue: ProvisionCluster
 
-  - name: PasswordToken
+  - name: TenantID
     type: Input
-    description: What is the token for accessing the cluster
-    dependsOnTrue: !expression "!ProvisionCluster"
+    description: "Enter your Azure tenant id:"
+    dependsOnTrue: ProvisionCluster
+
+  - name: ClientID
+    type: Input
+    description: "Enter your Azure client id:"
+    dependsOnTrue: ProvisionCluster
+
+  - name: ClientSecret
+    type: Input
+    description: "Enter your Azure client secret:"
     secret: true
+    dependsOnTrue: ProvisionCluster
+
+  # ############################################################################
+  # For the Terraform backend storage
+  # ############################################################################
+  - name: ResourceGroup
+    # Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period
+    type: Input
+    description: "Enter a new name for the Resource Group that will be created to house this cluster:"
+    pattern: "^[\\w._()-]{2,50}[\\w_()-]$"
+    dependsOnTrue: ProvisionCluster
+
+  - name: StorageAccountName
+    type: Input
+    description: "Enter the Storage Account where Terraform will store its state (see README.md step 3.2):"
+    dependsOnTrue: ProvisionCluster
+
+  - name: StorageAccessKey
+    type: Input
+    description: "Enter the Storage Account key for accessing the storage (see README.md step 3.3):"
+    dependsOnTrue: ProvisionCluster
+
+  - name: StorageContainerName
+    type: Input
+    description: "Enter the Storage Container name (see README.md step 3.4):"
+    default: terraform-state
+    dependsOnTrue: ProvisionCluster
+  # ############################################################################
 
   - name: ClusterName
     type: Input
     description: What name do you want to give the cluster?
     pattern: "^[[:alpha:]][\\w-]{1,29}[\\w]$"
+    # dependsOnTrue: ProvisionCluster
 
   - name: Namespace
     type: Input
-    value: xl-demo
+    default: xl-demo
 
-  # ############################################################################
-  # Authentication
-  # ############################################################################
-  - name: ClientID
+  - name: XLDUrlForXLR
     type: Input
-    description: What is the client id (appId) of an existing Service Principal in Azure?
-
-  - name: ClientSecret
-    type: Input
-    description: What is the secret for the above client id?
-    secret: true
-
-  - name: SubscriptionID
-    type: Input
-    description: What is your existing Azure subscription id?
-
-  - name: TenantID
-    type: Input
-    description: What is your existing Azure tenant id?
+    description: XL Deploy URL for XL Release (This will only be used in the XL Release template)
+    default: http://xl-deploy:4516
 
   # ############################################################################
   # Jenkins
@@ -130,31 +159,7 @@ spec:
     description: Store Admin password
     value: admin
     secret: true
-
   # ############################################################################
-  # For the Terraform backend storage
-  # ############################################################################
-  - name: StorageAccountName
-    type: Input
-    description: Existing Azure storage account where Terraform will store its state (see README.md on how to create this)
-    dependsOnTrue: ProvisionCluster
-
-  - name: StorageContainerName
-    type: Input
-    description: "Container within the storage account:"
-    default: terraform-state
-    dependsOnTrue: ProvisionCluster
-
-  - name: StorageAccessKey
-    type: Input
-    description: "One of the Azure access keys for accessing the storage:"
-    dependsOnTrue: ProvisionCluster
-  # ############################################################################
-
-  - name: XLDUrlForXLR
-    type: Input
-    description: XL Deploy URL for XL Release (This will only be used in the XL Release template)
-    default: http://xl-deploy:4516
 
   files:
   - path: xebialabs.yaml
@@ -183,6 +188,12 @@ spec:
   - path: terraform/aks/variables.tf
     dependsOnTrue: ProvisionCluster
   - path: terraform/aks/outputs.tf
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/vpc/main.tf
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/vpc/variables.tf
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/vpc/outputs.tf
     dependsOnTrue: ProvisionCluster
   # docker-compose setup for required tools
   - path: docker/docker-compose.yml.tmpl

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -76,12 +76,12 @@ spec:
   - name: ClusterEndpoint
     type: Input
     description: What is the endpoint for the cluster, example https://104.155.109.230
-    dependsOnFalse: ProvisionCluster
+    dependsOnTrue: !expression "!ProvisionCluster"
 
   - name: PasswordToken
     type: Input
     description: What is the token for accessing the cluster
-    dependsOnFalse: ProvisionCluster
+    dependsOnTrue: !expression "!ProvisionCluster"
     secret: true
 
   - name: ClusterName

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -91,8 +91,7 @@ spec:
 
   - name: Namespace
     type: Input
-    description: What namespace do you want to give the new cluster?
-    default: xl-demo
+    value: xl-demo
 
   # ############################################################################
   # Authentication

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -1,0 +1,190 @@
+apiVersion: xl/v1
+kind: Blueprint
+
+metadata:
+  projectName: Azure-Microservice-AKS-with-JHipster
+  description: |
+    The blueprint deploys an e-commerce microservice application to Azure AKS.
+    XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
+  author: XebiaLabs
+  version: 1.0
+
+spec:
+  parameters:
+  - name: AppName
+    type: Input
+    description: What do you want to name the application in XLD/XLR?
+
+  - name: ResourceGroup
+    # Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period
+    type: Input
+    description: "What do you want to name the Resource Group in Azure (Note: can be DESTROYED by Terraform at a later stage)?"
+    pattern: "^[\\w._()-]{2,50}[\\w_()-]$"
+
+  - name: AdminUsername
+    # Cannot be 'admin'
+    type: Input
+    description: What username do you want to use to access the cluster (cannot be 'admin')?
+    pattern: "^[[:alpha:]]+$"
+
+  - name: AdminUsernameSSHKeyPath
+    type: File
+    description: What is the path to the public SSH key for the above user?
+
+  - name: AKSRegion
+    type: Select
+    description: "Select the AKS region:"
+    options:
+    - eastasia
+    - southeastasia
+    - centralus
+    - eastus
+    - eastus2
+    - westus
+    - northcentralus
+    - southcentralus
+    - northeurope
+    - westeurope
+    - japanwest
+    - japaneast
+    - brazilsouth
+    - australiaeast
+    - australiasoutheast
+    - southindia
+    - centralindia
+    - westindia
+    - canadacentral
+    - canadaeast
+    - uksouth
+    - ukwest
+    - westcentralus
+    - westus2
+    - koreacentral
+    - koreasouth
+    - francecentral
+    - francesouth
+    - australiacentral
+    - australiacentral2
+    - southafricanorth
+    - southafricawest
+
+  - name: ProvisionCluster
+    type: Confirm
+    description: Do you want to provision a new Azure AKS cluster?
+
+  - name: ClusterEndpoint
+    type: Input
+    description: What is the endpoint for the cluster, example https://104.155.109.230
+    dependsOnFalse: ProvisionCluster
+
+  - name: PasswordToken
+    type: Input
+    description: What is the token for accessing the cluster
+    dependsOnFalse: ProvisionCluster
+    secret: true
+
+  - name: ClusterName
+    type: Input
+    description: What name do you want to give the cluster?
+    pattern: "^[[:alpha:]][\\w-]{1,29}[\\w]$"
+
+  - name: Namespace
+    type: Input
+    description: What namespace do you want to give the new cluster?
+    default: xl-demo
+
+  # ############################################################################
+  # Authentication
+  # ############################################################################
+  - name: ClientID
+    type: Input
+    description: What is the client id (appId) of an existing Service Principal in Azure?
+
+  - name: ClientSecret
+    type: Input
+    description: What is the secret for the above client id?
+    secret: true
+
+  - name: SubscriptionID
+    type: Input
+    description: What is your existing Azure subscription id?
+
+  - name: TenantID
+    type: Input
+    description: What is your existing Azure tenant id?
+
+  # ############################################################################
+  # Jenkins
+  # ############################################################################
+  - name: enableCICD
+    type: Confirm
+    description: Do you want to enable CI/CD integration with Jenkins?
+
+  - name: StoreAdminUsername
+    type: Input
+    description: Store Admin username
+    value: admin
+
+  - name: StoreAdminPassword
+    type: Input
+    description: Store Admin password
+    value: admin
+    secret: true
+
+  # ############################################################################
+  # For the Terraform backend storage
+  # ############################################################################
+  - name: StorageAccountName
+    type: Input
+    description: Existing Azure storage account where Terraform will store its state (see README.md on how to create this)
+    dependsOnTrue: ProvisionCluster
+
+  - name: StorageContainerName
+    type: Input
+    description: "Container within the storage account:"
+    default: terraform-state
+    dependsOnTrue: ProvisionCluster
+
+  - name: StorageAccessKey
+    type: Input
+    description: "One of the Azure access keys for accessing the storage:"
+    dependsOnTrue: ProvisionCluster
+  # ############################################################################
+
+  - name: XLDUrlForXLR
+    type: Input
+    description: XL Deploy URL for XL Release (This will only be used in the XL Release template)
+    default: http://xl-deploy:4516
+
+  files:
+  - path: xebialabs.yaml
+  - path: README.md
+  - path: xebialabs/xld-infra-env.yaml.tmpl
+  - path: xebialabs/xld-terraform-apps.yaml.tmpl
+  - path: xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
+  - path: xebialabs/xld-kubernetes-store-app.yaml.tmpl
+  - path: xebialabs/xld-kubernetes-notification-app.yaml.tmpl
+  - path: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+  - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl
+  - path: xebialabs/USAGE.md.tmpl
+  # Terraform
+  - path: terraform/main.tf
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/variables.tf.tmpl
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/backend.tf.tmpl
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/outputs.tf
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/.gitignore
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/aks/main.tf
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/aks/variables.tf
+    dependsOnTrue: ProvisionCluster
+  - path: terraform/aks/outputs.tf
+    dependsOnTrue: ProvisionCluster
+  # docker-compose setup for required tools
+  - path: docker/docker-compose.yml.tmpl
+  - path: docker/data/configure-xl-devops-platform.yaml
+  - path: docker/jenkins/jenkins.yaml

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -106,7 +106,7 @@ spec:
   - name: ResourceGroup
     # Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period
     type: Input
-    description: "Enter a new name for the Resource Group that will be created to house this cluster:"
+    description: "The blueprint will create a new Resource Group for the cluster. Please supply a name:"
     pattern: "^[\\w._()-]{2,50}[\\w_()-]$"
     dependsOnTrue: ProvisionCluster
 
@@ -199,3 +199,4 @@ spec:
   - path: docker/docker-compose.yml.tmpl
   - path: docker/data/configure-xl-devops-platform.yaml
   - path: docker/jenkins/jenkins.yaml
+    dependsOnTrue: enableCICD

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -8,6 +8,7 @@ metadata:
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
   author: XebiaLabs
   version: 1.0
+  instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
 
 spec:
   parameters:
@@ -170,7 +171,7 @@ spec:
   # Terraform
   - path: terraform/main.tf
     dependsOnTrue: ProvisionCluster
-  - path: terraform/variables.tf.tmpl
+  - path: terraform/variables.tf
     dependsOnTrue: ProvisionCluster
   - path: terraform/backend.tf.tmpl
     dependsOnTrue: ProvisionCluster

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -135,7 +135,7 @@ spec:
 
   - name: Namespace
     type: Input
-    default: xl-demo
+    value: xl-demo
 
   - name: XLDUrlForXLR
     type: Input

--- a/azure/microservice-ecommerce/docker/data/configure-xl-devops-platform.yaml
+++ b/azure/microservice-ecommerce/docker/data/configure-xl-devops-platform.yaml
@@ -1,0 +1,17 @@
+apiVersion: xl-release/v1
+kind: Templates
+spec:
+- name: XL Deploy
+  type: xldeploy.XLDeployServer
+  url: http://xl-deploy:4516
+  username: admin
+  password: admin
+---
+apiVersion: xl-release/v1
+kind: Templates
+spec:
+- name: jenkins
+  type: jenkins.Server
+  url: http://jenkins:8080
+  username: admin
+  password: admin

--- a/azure/microservice-ecommerce/docker/docker-compose.yml.tmpl
+++ b/azure/microservice-ecommerce/docker/docker-compose.yml.tmpl
@@ -1,0 +1,43 @@
+version: '3'
+services:
+  xl-deploy:
+    image: xebialabs/xl-jetpack-deploy:8.6.1
+    ports:
+    - "4516:4516"
+    environment:
+    - ADMIN_PASSWORD=admin
+    - ACCEPT_EULA=Y
+
+  xl-release:
+    image: xebialabs/xl-jetpack-release:8.6.1
+    ports:
+    - "5516:5516"
+    environment:
+    - ADMIN_PASSWORD=admin
+    - ACCEPT_EULA=Y
+
+  xl-cli:
+    image: xebialabsunsupported/xl-cli:8.6.1
+    depends_on:
+    - xl-deploy
+    - xl-release
+    command: ["apply", "--xl-deploy-url", "http://xl-deploy:4516/", "--xl-release-url", "http://xl-release:5516/", "-f", "/data/configure-xl-devops-platform.yaml"]
+    volumes:
+    - ./data/:/data:ro
+
+  {{ if .enableCICD }}
+  jenkins:
+    image: xebialabsunsupported/jenkins-blueprint-demo:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./jenkins/jenkins.yaml:/var/jenkins_home/casc_configs/jenkins.yaml
+    environment:
+      - CASC_JENKINS_CONFIG=/var/jenkins_home/casc_configs/jenkins.yaml
+      - GITHUB_USER=${GITHUB_USER}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - DOCKER_USER=${DOCKER_USER}
+      - DOCKER_PASS=${DOCKER_PASS}
+    ports:
+      - 8080:8080
+      - 55888:55888
+  {{ end }}

--- a/azure/microservice-ecommerce/docker/jenkins/jenkins.yaml
+++ b/azure/microservice-ecommerce/docker/jenkins/jenkins.yaml
@@ -1,0 +1,81 @@
+jenkins:
+  systemMessage: "Jenkins configured as code"
+  numExecutors: 3
+
+jobs:
+  - script: >
+      pipelineJob('devops-as-code-blueprint-store-svc') {
+          definition {
+              cpsScm {
+                  scm {
+                      git {
+                          branch("gke-blueprint")
+                          remote {
+                            credentials('github-credentials')
+                            url('https://github.com/${GITHUB_USER}/e-commerce-microservice.git')
+                          }
+                      }
+                  }
+                  scriptPath('store/Jenkinsfile')
+              }
+          }
+      }
+  - script: >
+      pipelineJob('devops-as-code-blueprint-notification-svc') {
+          definition {
+              cpsScm {
+                  scm {
+                      git {
+                          branch("gke-blueprint")
+                          remote {
+                        	credentials('github-credentials')
+                        	url('https://github.com/${GITHUB_USER}/e-commerce-microservice.git')
+                          }
+                      }
+                  }
+                  scriptPath('notification/Jenkinsfile')
+              }
+          }
+      }
+  - script: >
+      pipelineJob('devops-as-code-blueprint-invoice-svc') {
+          definition {
+              cpsScm {
+                  scm {
+                      git {
+                          branch("gke-blueprint")
+                          remote {
+                          credentials('github-credentials')
+                          url('https://github.com/${GITHUB_USER}/e-commerce-microservice.git')
+                          }
+                      }
+                  }
+                  scriptPath('invoice/Jenkinsfile')
+              }
+          }
+      }
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - usernamePassword:
+            scope:    GLOBAL
+            id:       github-credentials
+            username: ${GITHUB_USER}
+            password: ${GITHUB_TOKEN}
+        - usernamePassword:
+            scope:    GLOBAL
+            id:       xld-credentials
+            username: admin
+            password: admin
+        - usernamePassword:
+            scope:    GLOBAL
+            id:       xlr-credentials
+            username: admin
+            password: admin
+        - usernamePassword:
+            scope:    GLOBAL
+            id:       docker-login
+            username: ${DOCKER_USER}
+            password: ${DOCKER_PASS}

--- a/azure/microservice-ecommerce/terraform/.gitignore
+++ b/azure/microservice-ecommerce/terraform/.gitignore
@@ -1,0 +1,5 @@
+*.tfstate
+*.tfstate.backup
+*.tfvars
+.terraform
+tfplan

--- a/azure/microservice-ecommerce/terraform/aks/main.tf
+++ b/azure/microservice-ecommerce/terraform/aks/main.tf
@@ -1,6 +1,12 @@
 resource "azurerm_resource_group" "k8s" {
-  name     = "${var.resource_group}"
+  name     = "${var.resource_group_name}"
   location = "${var.location}"
+}
+
+resource "tls_private_key" "key" {
+  algorithm   = "RSA"
+  ecdsa_curve = "P224"
+  rsa_bits    = "4096"
 }
 
 resource "azurerm_kubernetes_cluster" "k8s" {
@@ -15,6 +21,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     vm_size         = "${var.vm_size}"
     os_type         = "Linux"
     os_disk_size_gb = 30
+    vnet_subnet_id  = "${var.subnet_id}"
   }
 
   service_principal {
@@ -22,12 +29,16 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     client_secret = "${var.client_secret}"
   }
 
+  network_profile {
+    network_plugin = "azure"
+  }
+
   linux_profile {
     # WARNING: The name 'admin' is not allowed
     admin_username = "${var.admin_username}"
 
     ssh_key {
-      key_data = "${var.ssh_public_key_path}"
+      key_data = "${trimspace(tls_private_key.key.public_key_openssh)}"
     }
   }
 

--- a/azure/microservice-ecommerce/terraform/aks/main.tf
+++ b/azure/microservice-ecommerce/terraform/aks/main.tf
@@ -1,0 +1,37 @@
+resource "azurerm_resource_group" "k8s" {
+  name     = "${var.resource_group}"
+  location = "${var.location}"
+}
+
+resource "azurerm_kubernetes_cluster" "k8s" {
+  name                = "${var.cluster_name}"
+  location            = "${azurerm_resource_group.k8s.location}"
+  resource_group_name = "${azurerm_resource_group.k8s.name}"
+  dns_prefix          = "${var.dns_prefix}"
+
+  agent_pool_profile {
+    name            = "default"
+    count           = "${var.node_count}"
+    vm_size         = "${var.vm_size}"
+    os_type         = "Linux"
+    os_disk_size_gb = 30
+  }
+
+  service_principal {
+    client_id     = "${var.client_id}"
+    client_secret = "${var.client_secret}"
+  }
+
+  linux_profile {
+    # WARNING: The name 'admin' is not allowed
+    admin_username = "${var.admin_username}"
+
+    ssh_key {
+      key_data = "${var.ssh_public_key_path}"
+    }
+  }
+
+  tags {
+    Environment = "Demo"
+  }
+}

--- a/azure/microservice-ecommerce/terraform/aks/outputs.tf
+++ b/azure/microservice-ecommerce/terraform/aks/outputs.tf
@@ -1,0 +1,12 @@
+output "host" {
+  value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.host}"
+}
+
+output "password" {
+  value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.password}"
+}
+
+output "client_certificate" {
+  value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.client_certificate}"
+}
+

--- a/azure/microservice-ecommerce/terraform/aks/variables.tf
+++ b/azure/microservice-ecommerce/terraform/aks/variables.tf
@@ -1,4 +1,4 @@
-variable "resource_group" {
+variable "resource_group_name" {
   description = "A resource group is a collection of resources that share the same lifecycle, permissions, and policies"
 }
 
@@ -22,10 +22,6 @@ variable "admin_username" {
   description = "The username for the cluster (cannot be 'admin')"
 }
 
-variable "ssh_public_key_path" {
-  description = ""
-}
-
 variable "client_id" {
   description = "The appId of the Service Principal"
 }
@@ -36,5 +32,9 @@ variable "client_secret" {
 
 variable "dns_prefix" {
   description = "DNS name prefix to use with the hosted Kubernetes API server FQDN. You will use this to connect to the Kubernetes API when managing containers after creating the cluster"
+}
+
+variable "subnet_id" {
+
 }
 

--- a/azure/microservice-ecommerce/terraform/aks/variables.tf
+++ b/azure/microservice-ecommerce/terraform/aks/variables.tf
@@ -1,0 +1,40 @@
+variable "resource_group" {
+  description = "A resource group is a collection of resources that share the same lifecycle, permissions, and policies"
+}
+
+variable "cluster_name" {
+  description = "The name of the Azure Kubernetes Service cluster"
+}
+
+variable "location" {
+  description = "Location of resources"
+}
+
+variable "vm_size" {
+  description = "The type of VM"
+}
+
+variable "node_count" {
+  description = "The size of the virtual machines that will form the nodes in the cluster. This cannot be changed after creating the cluster"
+}
+
+variable "admin_username" {
+  description = "The username for the cluster (cannot be 'admin')"
+}
+
+variable "ssh_public_key_path" {
+  description = ""
+}
+
+variable "client_id" {
+  description = "The appId of the Service Principal"
+}
+
+variable "client_secret" {
+  description = "The password of the Service Principal"
+}
+
+variable "dns_prefix" {
+  description = "DNS name prefix to use with the hosted Kubernetes API server FQDN. You will use this to connect to the Kubernetes API when managing containers after creating the cluster"
+}
+

--- a/azure/microservice-ecommerce/terraform/backend.tf.tmpl
+++ b/azure/microservice-ecommerce/terraform/backend.tf.tmpl
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    storage_account_name = "{{.StorageAccountName}}"
+    container_name       = "{{.StorageContainerName}}"
+    key                  = "terraform.tfstate"
+    access_key           = "{{.StorageAccessKey}}"
+  }
+}

--- a/azure/microservice-ecommerce/terraform/main.tf
+++ b/azure/microservice-ecommerce/terraform/main.tf
@@ -1,22 +1,33 @@
 provider "azurerm" {
-  version = "=1.24.0"
-
+  version         = "=1.24.0"
   subscription_id = "${var.subscription_id}"
   client_id       = "${var.client_id}"
   client_secret   = "${var.client_secret}"
   tenant_id       = "${var.tenant_id}"
 }
 
+resource "azurerm_resource_group" "k8s" {
+  name     = "${var.resource_group_name}"
+  location = "${var.location}"
+}
+
+module "vpc" {
+  source              = "./vpc"
+  name                = "${var.cluster_name}"
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+}
+
 module "aks" {
   source              = "./aks"
-  resource_group      = "${var.resource_group}"
-  cluster_name        = "${var.cluster_name}"
   location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+  cluster_name        = "${var.cluster_name}"
   vm_size             = "${var.vm_size}"
   node_count          = "${var.node_count}"
   admin_username      = "${var.admin_username}"
   client_id           = "${var.client_id}"
   client_secret       = "${var.client_secret}"
   dns_prefix          = "${var.dns_prefix}"
-  ssh_public_key_path = "${var.ssh_public_key_path}"
+  subnet_id           = "${module.vpc.subnet_id}"
 }

--- a/azure/microservice-ecommerce/terraform/main.tf
+++ b/azure/microservice-ecommerce/terraform/main.tf
@@ -1,0 +1,22 @@
+provider "azurerm" {
+  version = "=1.24.0"
+
+  subscription_id = "${var.subscription_id}"
+  client_id       = "${var.client_id}"
+  client_secret   = "${var.client_secret}"
+  tenant_id       = "${var.tenant_id}"
+}
+
+module "aks" {
+  source              = "./aks"
+  resource_group      = "${var.resource_group}"
+  cluster_name        = "${var.cluster_name}"
+  location            = "${var.location}"
+  vm_size             = "${var.vm_size}"
+  node_count          = "${var.node_count}"
+  admin_username      = "${var.admin_username}"
+  client_id           = "${var.client_id}"
+  client_secret       = "${var.client_secret}"
+  dns_prefix          = "${var.dns_prefix}"
+  ssh_public_key_path = "${var.ssh_public_key_path}"
+}

--- a/azure/microservice-ecommerce/terraform/outputs.tf
+++ b/azure/microservice-ecommerce/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "host" {
+  value = "${module.aks.host}"
+}
+
+output "password" {
+  value = "${module.aks.password}"
+}
+
+output "client_certificate" {
+  value = "${module.aks.client_certificate}"
+}

--- a/azure/microservice-ecommerce/terraform/variables.tf
+++ b/azure/microservice-ecommerce/terraform/variables.tf
@@ -26,13 +26,11 @@ variable "node_count" {
 variable "admin_username" {
   # * AdminUsername
   description = "The username for the cluster (cannot be 'admin')"
-  default     = "jjohnson"
 }
 
 variable "ssh_public_key_path" {
   # * AdminUsernameSSHKeyPath
-  description = ""
-  default     = "{{.AdminUsernameSSHKeyPath | trim}}"
+  description = "The SSH key for the admin user"
 }
 
 variable "client_id" {

--- a/azure/microservice-ecommerce/terraform/variables.tf
+++ b/azure/microservice-ecommerce/terraform/variables.tf
@@ -1,4 +1,4 @@
-variable "resource_group" {
+variable "resource_group_name" {
   # * ResourceGroup
   description = "A resource group is a collection of resources that share the same lifecycle, permissions, and policies"
 }
@@ -26,11 +26,7 @@ variable "node_count" {
 variable "admin_username" {
   # * AdminUsername
   description = "The username for the cluster (cannot be 'admin')"
-}
-
-variable "ssh_public_key_path" {
-  # * AdminUsernameSSHKeyPath
-  description = "The SSH key for the admin user"
+  default     = "adminuser"
 }
 
 variable "client_id" {

--- a/azure/microservice-ecommerce/terraform/variables.tf.tmpl
+++ b/azure/microservice-ecommerce/terraform/variables.tf.tmpl
@@ -1,0 +1,62 @@
+variable "resource_group" {
+  # * ResourceGroup
+  description = "A resource group is a collection of resources that share the same lifecycle, permissions, and policies"
+}
+
+variable "cluster_name" {
+  # * ClusterName
+  description = "The name of the Azure Kubernetes Service cluster"
+}
+
+variable "location" {
+  # * AKSRegion
+  description = "Location of resources"
+}
+
+variable "vm_size" {
+  description = "The type of VM"
+  default     = "Standard_B2ms"
+}
+
+variable "node_count" {
+  description = "The size of the virtual machines that will form the nodes in the cluster. This cannot be changed after creating the cluster"
+  default     = 3
+}
+
+variable "admin_username" {
+  # * AdminUsername
+  description = "The username for the cluster (cannot be 'admin')"
+  default     = "jjohnson"
+}
+
+variable "ssh_public_key_path" {
+  # * AdminUsernameSSHKeyPath
+  description = ""
+  default     = "{{.AdminUsernameSSHKeyPath | trim}}"
+}
+
+variable "client_id" {
+  # * ClientID
+  description = "The appId of the Service Principal"
+}
+
+variable "client_secret" {
+  # * ClientSecret
+  description = "The password of the Service Principal"
+}
+
+variable "subscription_id" {
+  # * SubscriptionID
+  description = "The Azure subscription id"
+}
+
+variable "tenant_id" {
+  # * TenantID
+  description = "The Azure tenant id"
+}
+
+variable "dns_prefix" {
+  description = "DNS name prefix to use with the hosted Kubernetes API server FQDN. You will use this to connect to the Kubernetes API when managing containers after creating the cluster"
+  default     = "k8s"
+}
+

--- a/azure/microservice-ecommerce/terraform/vpc/main.tf
+++ b/azure/microservice-ecommerce/terraform/vpc/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "vnet" {
-  name                = "jeff-vnet"
+  name                = "${var.name}-vnet"
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
   address_space       = ["10.1.0.0/16"]
@@ -7,20 +7,20 @@ resource "azurerm_virtual_network" "vnet" {
 
 resource "azurerm_subnet" "subnet" {
   depends_on           = ["azurerm_virtual_network.vnet"]
-  name                 = "internal"
+  name                 = "${var.name}-internal"
   resource_group_name  = "${var.resource_group_name}"
   address_prefix       = "10.1.2.0/24"
   virtual_network_name = "${azurerm_virtual_network.vnet.name}"
 }
 
 resource "azurerm_network_security_group" "security" {
-  name                = "jjohnson-nsg"
+  name                = "${var.name}-nsg"
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 }
 
 resource "azurerm_network_security_rule" "ssh_https" {
-  name                        = "ssh_https"
+  name                        = "${var.name}-ssh_https"
   priority                    = 100
   direction                   = "Inbound"
   access                      = "Allow"

--- a/azure/microservice-ecommerce/terraform/vpc/main.tf
+++ b/azure/microservice-ecommerce/terraform/vpc/main.tf
@@ -1,0 +1,34 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = "jeff-vnet"
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+  address_space       = ["10.1.0.0/16"]
+}
+
+resource "azurerm_subnet" "subnet" {
+  depends_on           = ["azurerm_virtual_network.vnet"]
+  name                 = "internal"
+  resource_group_name  = "${var.resource_group_name}"
+  address_prefix       = "10.1.2.0/24"
+  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
+}
+
+resource "azurerm_network_security_group" "security" {
+  name                = "jjohnson-nsg"
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+}
+
+resource "azurerm_network_security_rule" "ssh_https" {
+  name                        = "ssh_https"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_ranges     = [22, 6443]
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${var.resource_group_name}"
+  network_security_group_name = "${azurerm_network_security_group.security.name}"
+}

--- a/azure/microservice-ecommerce/terraform/vpc/outputs.tf
+++ b/azure/microservice-ecommerce/terraform/vpc/outputs.tf
@@ -1,0 +1,3 @@
+output "subnet_id" {
+  value = "${azurerm_subnet.subnet.id}"
+}

--- a/azure/microservice-ecommerce/terraform/vpc/variables.tf
+++ b/azure/microservice-ecommerce/terraform/vpc/variables.tf
@@ -1,0 +1,3 @@
+variable "name" { }
+variable "location" { }
+variable "resource_group_name" { }

--- a/azure/microservice-ecommerce/xebialabs.yaml
+++ b/azure/microservice-ecommerce/xebialabs.yaml
@@ -1,0 +1,11 @@
+apiVersion: xl/v1
+kind: Import
+metadata:
+  imports:
+    - xebialabs/xld-infra-env.yaml
+    - xebialabs/xld-terraform-apps.yaml
+    - xebialabs/xld-kubernetes-invoice-app.yaml
+    - xebialabs/xld-kubernetes-notification-app.yaml
+    - xebialabs/xld-kubernetes-store-app.yaml
+    - xebialabs/xlr-pipeline-ci-cd.yaml
+    - xebialabs/xlr-pipeline-destroy.yaml

--- a/azure/microservice-ecommerce/xebialabs/USAGE.md.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/USAGE.md.tmpl
@@ -44,6 +44,8 @@ docker-compose up -d xl-cli
 
 ## Step 3: Deploy the blueprint
 
+> **Note:** Please read the instructions in [azure/microservice-ecommerce/README.md](https://github.com/xebialabs/blueprints/blob/development/azure/microservice-ecommerce/README.md) to prepare the environment before proceeding.
+
 1. Inside the `e-commerce-microservice` directory, apply the generated `.yaml` configurations using the XL CLI.
 
 ```plain

--- a/azure/microservice-ecommerce/xebialabs/USAGE.md.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/USAGE.md.tmpl
@@ -1,0 +1,62 @@
+{{$app := .AppName | kebabcase}}
+
+# Prerequisites
+* You must have [Docker](https://docs.docker.com/install/) for your platfo
+* You must have [docker-compose](https://docs.docker.com/compose/install/) installed
+
+# Launch local environment
+
+Follow the below instructions to get XLD and XLR (and Jenkins) running so you can deploy the blueprint.
+
+## Step 1: Set environment variables (if you are using Jenkins CI/CD)
+
+If you intend to use the Jenkins CI/CD pipeline to generate your own Docker images, you will need to set the following environment variables before running `docker-compose up` (see below) in the same terminal session:
+
+```ini
+GITHUB_USER=<GITHUB USER>
+GITHUB_TOKEN=<GITHUB API TOKEN>
+DOCKER_USER=<YOUR DOCKER USERNAME>
+DOCKER_PASS=<YOUR DOCKER PASSWORD>
+```
+
+You will also need to modify the Docker image names to your own GitHub user account.
+
+1. Replace the occurrences of `xebialabsunsupported` in the `kubernetes/*-deployment.yml` files with your own DockerHub ID
+2. Push the cloned repository to your GitHub account so that Jenkins can checkout `https://github.com/${GITHUB_USER}/e-commerce-microservice.git`
+
+## Step 2: Make sure XL Deploy and XL Release (and Jenkins) are running
+
+> **Note:** If you already have XL Deploy and XL Release (and Jenkins) servers running, you can skip this step.
+
+The blueprint generates `docker/docker-compose.yml`. This will start up XLD and XLR (and Jenkins). Inside the `e-commerce-microservice` directory run:
+
+```plain
+cd docker
+docker-compose up
+```
+
+This will start the services and take control of the terminal. You will need to open a new terminal to continue.
+
+> **Note:** Watch the log output for `docker_xl-cli_1`. Its job is to connect XL Release to XL Deploy. It must exit with code `0`. If not, open a new terminal in the same directory and run:
+```plain
+docker-compose up -d xl-cli
+```
+
+## Step 3: Deploy the blueprint
+
+1. Inside the `e-commerce-microservice` directory, apply the generated `.yaml` configurations using the XL CLI.
+
+```plain
+xl apply -f xebialabs.yaml
+```
+
+2. Go to XL Release (default http://localhost:5516) and look for the "{{$app}}-ci-cd" template and start a new release from it.
+3. Once you are done, go back to XL Release, look for the "{{$app}}-destroy" template and start a new release from it to automatically rollback and destroy the resources you created.
+
+## Minimum Required versions
+
+This blueprint version requires at least the below versions of the specified tools to work properly.
+
+XL Release: Version 8.6
+XL Deploy: Version 8.6.1
+XL CLI: Version 8.6

--- a/azure/microservice-ecommerce/xebialabs/xld-infra-env.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-infra-env.yaml.tmpl
@@ -8,7 +8,7 @@ spec:
 - name: {{$app}}
   type: core.Directory
   children:
-  - name: terraform
+  - name: azure-terraform
     type: overthere.LocalHost
     os: UNIX
     children:
@@ -24,11 +24,11 @@ spec:
 - name: {{$app}}
   type: core.Directory
   children:
-  - name: terraform
+  - name: azure-terraform
     type: udm.Environment
     members:
-    - Infrastructure/{{$app}}/terraform
-    - Infrastructure/{{$app}}/terraform/terraform-client
+    - Infrastructure/{{$app}}/azure-terraform
+    - Infrastructure/{{$app}}/azure-terraform/terraform-client
 
 {{else}}
 # Definition of existing AKS cluster
@@ -38,7 +38,7 @@ spec:
 - name: {{$app}}
   type: core.Directory
   children:
-  - name: {{$clusterName}}
+  - name: azure-aks-{{$clusterName}}
     type: k8s.Master
     apiServerURL: {{.ClusterEndpoint}}
     skipTLS: true
@@ -55,9 +55,9 @@ spec:
 - name: {{$app}}
   type: core.Directory
   children:
-  - name: {{$clusterName}}
+  - name: azure-aks-{{$app}}
     type: udm.Environment
     members:
-    - Infrastructure/{{$app}}/{{$clusterName}}/{{.Namespace | kebabcase}}
-    - Infrastructure/{{$app}}/{{$clusterName}}
+    - Infrastructure/{{$app}}/azure-aks-{{$clusterName}}/{{.Namespace | kebabcase}}
+    - Infrastructure/{{$app}}/azure-aks-{{$clusterName}}
 {{end}}

--- a/azure/microservice-ecommerce/xebialabs/xld-infra-env.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-infra-env.yaml.tmpl
@@ -1,0 +1,63 @@
+{{$app := .AppName | kebabcase}}
+{{$clusterName := .ClusterName | kebabcase}}
+{{if .ProvisionCluster }}
+# Provision Azure AKS cluster
+apiVersion: xl-deploy/v1
+kind: Infrastructure
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+  - name: terraform
+    type: overthere.LocalHost
+    os: UNIX
+    children:
+    - name: terraform-client
+      type: terraform.TerraformClient
+      path: '/usr/local/bin' # for local installation
+      workingDirectory: '/tmp/{{$app}}' # for local installation
+
+---
+apiVersion: xl-deploy/v1
+kind: Environments
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+  - name: terraform
+    type: udm.Environment
+    members:
+    - Infrastructure/{{$app}}/terraform
+    - Infrastructure/{{$app}}/terraform/terraform-client
+
+{{else}}
+# Definition of existing AKS cluster
+apiVersion: xl-deploy/v1
+kind: Infrastructure
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+  - name: {{$clusterName}}
+    type: k8s.Master
+    apiServerURL: {{.ClusterEndpoint}}
+    skipTLS: true
+    token: {{.PasswordToken}}
+    children:
+    - name: {{.Namespace | kebabcase}}
+      type: k8s.Namespace
+      namespaceName: {{.Namespace}}
+---
+# Definition of existing AKS Environment
+apiVersion: xl-deploy/v1
+kind: Environments
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+  - name: {{$clusterName}}
+    type: udm.Environment
+    members:
+    - Infrastructure/{{$app}}/{{$clusterName}}/{{.Namespace | kebabcase}}
+    - Infrastructure/{{$app}}/{{$clusterName}}
+{{end}}

--- a/azure/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
@@ -1,0 +1,31 @@
+{{$app := .AppName | kebabcase}}
+apiVersion: xl-deploy/v1
+kind: Applications
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+    - name: K8S
+      type: core.Directory
+      children:
+      - name: {{$app}}-invoice-mysql
+        type: udm.Application
+        children:
+        - name: 1.0.0
+          type: udm.DeploymentPackage
+          deployables:
+          - name: {{$app}}-invoice-mysql
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/invoice/invoice-mysql.yml
+      - name: {{$app}}-invoice
+        type: udm.Application
+        children:
+        - name: 1.0.0
+          type: udm.DeploymentPackage
+          deployables:
+          - name: {{$app}}-invoice-deployment
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/invoice/invoice-deployment.yml
+          - name: {{$app}}-invoice-svc
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/invoice/invoice-service.yml

--- a/azure/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
@@ -1,0 +1,31 @@
+{{$app := .AppName | kebabcase}}
+apiVersion: xl-deploy/v1
+kind: Applications
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+    - name: K8S
+      type: core.Directory
+      children:
+      - name: {{$app}}-notification-mongodb
+        type: udm.Application
+        children:
+        - name: 1.0.0
+          type: udm.DeploymentPackage
+          deployables:
+          - name: {{$app}}-notification-mongodb
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/notification/notification-mongodb.yml
+      - name: {{$app}}-notification
+        type: udm.Application
+        children:
+        - name: 1.0.0
+          type: udm.DeploymentPackage
+          deployables:
+          - name: {{$app}}-invoice-notification
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/notification/notification-deployment.yml
+          - name: {{$app}}-notification-svc
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/notification/notification-service.yml

--- a/azure/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
@@ -1,0 +1,43 @@
+{{$app := .AppName | kebabcase}}
+apiVersion: xl-deploy/v1
+kind: Applications
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+    - name: K8S
+      type: core.Directory
+      children:
+      - name: {{$app}}-store-mysql
+        type: udm.Application
+        children:
+        - name: 1.0.0
+          type: udm.DeploymentPackage
+          deployables:
+          - name: {{$app}}-store-mysql
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/store/store-mysql.yml
+      - name: {{$app}}-registry
+        type: udm.Application
+        children:
+        - name: 1.0.0
+          type: udm.DeploymentPackage
+          deployables:
+          - name: {{$app}}-application-config
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/registry/application-configmap.yml
+          - name: {{$app}}-jhipster-registry
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/registry/jhipster-registry.yml
+      - name: {{$app}}-store
+        type: udm.Application
+        children:
+        - name: 1.0.0
+          type: udm.DeploymentPackage
+          deployables:
+          - name: {{$app}}-store-deployment
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/store/store-deployment.yml
+          - name: {{$app}}-store-svc
+            type: k8s.ResourcesFile
+            file: !file ../kubernetes/store/store-service.yml

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -29,6 +29,8 @@ spec:
             client_secret: !value ClientSecret
             subscription_id: {{.SubscriptionID}}
             tenant_id: {{.TenantID}}
+            admin_username: {{.AdminUsername}}
+            ssh_public_key_path: {{.AdminUsernameSSHKeyPath}}
           boundTemplates:
           - "../{{$clusterName}}"
           - "../{{$clusterName}}-env"

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -11,13 +11,13 @@ spec:
   - name: AKS-TERRAFORM
     type: core.Directory
     children:
-    - name: {{$app}}-terraform
+    - name: {{$app}}-terraform-aks
       type: udm.Application
       children:
       - name: '1.0.0'
         type: udm.DeploymentPackage
         deployables:
-        - name: {{$app}}
+        - name: {{$app}}-aks
           type: terraform.Module
           file: !file ../terraform
           inputVariables:
@@ -30,23 +30,22 @@ spec:
             subscription_id: {{.SubscriptionID}}
             tenant_id: {{.TenantID}}
           boundTemplates:
-          - "../{{$clusterName}}-master"
-          - "../{{$clusterName}}-env"
+          - "../azure-aks-{{$clusterName}}"
+          - "../azure-aks-{{$clusterName}}-env"
 
         templates:
         # creates the required XLD infrastructure entries
-        - name: {{$clusterName}}-master
+        - name: azure-aks-{{$clusterName}}
           type: template.k8s.Master
           apiServerURL: '{{"{{%outputVariables.host%}}"}}'
           skipTLS: true
-          token: '{{"{{%outputVariables.password%}}"}}'
-          instanceName: {{$app}}/{{$clusterName}}
+          instanceName: {{$app}}/azure-aks-{{$clusterName}}
         # creates a new environment for Kubernetes deployments
-        - name: {{$clusterName}}-env
+        - name: azure-aks-{{$clusterName}}-env
           type: template.udm.Environment
           members:
-          - "../{{$clusterName}}"
-          instanceName: {{$app}}/{{$clusterName}}
+          - "../azure-aks-{{$clusterName}}"
+          instanceName: {{$app}}/azure-aks-{{$clusterName}}
 
 {{end}}
   - name: K8S

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -30,12 +30,12 @@ spec:
             subscription_id: {{.SubscriptionID}}
             tenant_id: {{.TenantID}}
           boundTemplates:
-          - "../{{$clusterName}}"
+          - "../{{$clusterName}}-master"
           - "../{{$clusterName}}-env"
 
         templates:
         # creates the required XLD infrastructure entries
-        - name: {{$clusterName}}
+        - name: {{$clusterName}}-master
           type: template.k8s.Master
           apiServerURL: '{{"{{%outputVariables.host%}}"}}'
           skipTLS: true

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -30,7 +30,7 @@ spec:
             subscription_id: {{.SubscriptionID}}
             tenant_id: {{.TenantID}}
             admin_username: {{.AdminUsername}}
-            ssh_public_key_path: {{.AdminUsernameSSHKeyPath}}
+            ssh_public_key_path: {{.AdminUsernameSSHKeyPath | trim}}
           boundTemplates:
           - "../{{$clusterName}}"
           - "../{{$clusterName}}-env"

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -39,6 +39,7 @@ spec:
           type: template.k8s.Master
           apiServerURL: '{{"{{%outputVariables.host%}}"}}'
           skipTLS: true
+          token: '{{"{{%outputVariables.password%}}"}}'
           instanceName: {{$app}}/azure-aks-{{$clusterName}}
         # creates a new environment for Kubernetes deployments
         - name: azure-aks-{{$clusterName}}-env

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -22,15 +22,13 @@ spec:
           file: !file ../terraform
           inputVariables:
             name: {{$app}}
-            resource_group: {{.ResourceGroup}}
+            resource_group_name: {{.ResourceGroup}}
             cluster_name: {{.ClusterName}}
             location: {{.AKSRegion}}
             client_id: {{.ClientID}}
             client_secret: !value ClientSecret
             subscription_id: {{.SubscriptionID}}
             tenant_id: {{.TenantID}}
-            admin_username: {{.AdminUsername}}
-            ssh_public_key_path: {{.AdminUsernameSSHKeyPath | trim}}
           boundTemplates:
           - "../{{$clusterName}}"
           - "../{{$clusterName}}-env"

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -1,0 +1,66 @@
+{{$app := .AppName | kebabcase}}
+{{$clusterName := .ClusterName | kebabcase}}
+apiVersion: xl-deploy/v1
+kind: Applications
+spec:
+- name: {{$app}}
+  type: core.Directory
+  children:
+{{if .ProvisionCluster }}
+# Provision AKS cluster using Terraform templates
+  - name: AKS-TERRAFORM
+    type: core.Directory
+    children:
+    - name: {{$app}}-terraform
+      type: udm.Application
+      children:
+      - name: '1.0.0'
+        type: udm.DeploymentPackage
+        deployables:
+        - name: {{$app}}
+          type: terraform.Module
+          file: !file ../terraform
+          inputVariables:
+            name: {{$app}}
+            resource_group: {{.ResourceGroup}}
+            cluster_name: {{.ClusterName}}
+            location: {{.AKSRegion}}
+            client_id: {{.ClientID}}
+            client_secret: !value ClientSecret
+            subscription_id: {{.SubscriptionID}}
+            tenant_id: {{.TenantID}}
+          boundTemplates:
+          - "../{{$clusterName}}"
+          - "../{{$clusterName}}-env"
+
+        templates:
+        # creates the required XLD infrastructure entries
+        - name: {{$clusterName}}
+          type: template.k8s.Master
+          apiServerURL: '{{"{{%outputVariables.host%}}"}}'
+          skipTLS: true
+          token: '{{"{{%outputVariables.password%}}"}}'
+          instanceName: {{$app}}/{{$clusterName}}
+        # creates a new environment for Kubernetes deployments
+        - name: {{$clusterName}}-env
+          type: template.udm.Environment
+          members:
+          - "../{{$clusterName}}"
+          instanceName: {{$app}}/{{$clusterName}}
+
+{{end}}
+  - name: K8S
+    type: core.Directory
+{{if .ProvisionCluster }}
+# Provision K8s namespace
+    children:
+    - name: {{$app}}-namespace
+      type: udm.Application
+      children:
+      - name: '1.0.0'
+        type: udm.DeploymentPackage
+        deployables:
+        - name: {{.Namespace}}
+          type: k8s.NamespaceSpec
+          namespaceName: '{{.Namespace}}'
+{{end}}

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -1,0 +1,209 @@
+{{$app := .AppName | kebabcase}}
+{{$clusterName := .ClusterName | kebabcase}}
+{{$appEnv := .ClusterName | kebabcase}}
+apiVersion: xl-release/v1
+kind: Templates
+spec:
+- name: {{$app}}
+  type: xlrelease.Folder
+  children:
+  - name: {{$app}}-ci-cd
+    type: xlrelease.Release
+    description: |
+      This XL Release template shows how to deploy an application, based on microservices architecture, to Azure AKS using XL Deploy and Terraform.
+    tags:
+    - Azure
+    - AKS
+    - Terraform
+    - {{$app}}
+    scriptUsername: !value XL_RELEASE_USERNAME
+    scriptUserPassword: !value XL_RELEASE_PASSWORD
+    variables:
+    - key: control
+      type: xlrelease.MapStringStringVariable
+      requiresValue: false
+      showOnReleaseStart: false
+      value:
+        namespace: {{.Namespace}}
+        serviceName: store
+    - key: lbHostnameOrIp
+      type: xlrelease.StringVariable
+      requiresValue: false
+      showOnReleaseStart: false
+
+    - key: store-admin-username
+      type: xlrelease.StringVariable
+      requiresValue: true
+      showOnReleaseStart: false
+      value: {{.StoreAdminUsername}}
+    - key: store-admin-password
+      type: xlrelease.StringVariable
+      requiresValue: true
+      showOnReleaseStart: false
+      value: {{.StoreAdminPassword}}
+    - key: xld-admin-password
+      type: xlrelease.PasswordStringVariable
+      requiresValue: true
+      showOnReleaseStart: false
+      value: !value XL_DEPLOY_PASSWORD
+    phases:
+    {{if .ProvisionCluster }}
+    - name: Provision Infrastructure
+      color: '#ff9e3b'
+      type: xlrelease.Phase
+      tasks:
+      - name: Provision Azure AKS cluster
+        type: xldeploy.Deploy
+        server: XL Deploy
+        deploymentPackage: {{$app}}/AKS-TERRAFORM/{{$app}}-terraform/1.0.0
+        deploymentEnvironment: Environments/{{$app}}/terraform
+    {{end}}
+    {{if .enableCICD }}
+    - name: Build {{$app}} application
+      type: xlrelease.Phase
+      tasks:
+      - name: Build docker images for {{$app}} services
+        type: xlrelease.ParallelGroup
+        tasks:
+        - name: Build {{$app}} store docker image
+          type: jenkins.Build
+          jenkinsServer: jenkins
+          jobName: devops-as-code-blueprint-store-svc
+          owner: admin
+        - name: Build {{$app}} notification docker image
+          type: jenkins.Build
+          jenkinsServer: jenkins
+          jobName: devops-as-code-blueprint-notification-svc
+          owner: admin
+        - name: Build {{$app}} invoice docker image
+          type: jenkins.Build
+          jenkinsServer: jenkins
+          jobName: devops-as-code-blueprint-invoice-svc
+          owner: admin
+    {{end}}
+    - name: Deploy {{$app}} application
+      type: xlrelease.Phase
+      tasks:
+      {{if .ProvisionCluster }}
+      - name: Deploy {{.Namespace}} namespace
+        type: xldeploy.Deploy
+        server: XL Deploy
+        deploymentPackage: {{$app}}/K8S/{{$app}}-namespace/1.0.0
+        deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+      {{end}}
+      - name: Deploy stateful services
+        type: xlrelease.ParallelGroup
+        tasks:
+        - name: Deploy invoice mysql svc
+          type: xldeploy.Deploy
+          server: XL Deploy
+          deploymentPackage: {{$app}}/K8S/{{$app}}-invoice-mysql/1.0.0
+          deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+        - name: Deploy store mysql svc
+          type: xldeploy.Deploy
+          server: XL Deploy
+          deploymentPackage: {{$app}}/K8S/{{$app}}-store-mysql/1.0.0
+          deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+        - name: Deploy notification mongodb svc
+          type: xldeploy.Deploy
+          server: XL Deploy
+          deploymentPackage: {{$app}}/K8S/{{$app}}-notification-mongodb/1.0.0
+          deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+      - name: Deploy stateless services
+        type: xlrelease.SequentialGroup
+        tasks:
+        - name: Deploy registry svc
+          type: xldeploy.Deploy
+          server: XL Deploy
+          deploymentPackage: {{$app}}/K8S/{{$app}}-registry/1.0.0
+          deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+        - name: Deploy microservices
+          type: xlrelease.ParallelGroup
+          tasks:
+          - name: Deploy invoice svc
+            type: xldeploy.Deploy
+            server: XL Deploy
+            deploymentPackage: {{$app}}/K8S/{{$app}}-invoice/1.0.0
+            deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+          - name: Deploy notification svc
+            type: xldeploy.Deploy
+            server: XL Deploy
+            deploymentPackage: {{$app}}/K8S/{{$app}}-notification/1.0.0
+            deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+          - name: Deploy store svc
+            type: xldeploy.Deploy
+            server: XL Deploy
+            deploymentPackage: {{$app}}/K8S/{{$app}}-store/1.0.0
+            deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+    - name: Test
+      type: xlrelease.Phase
+      tasks:
+      - name: Get Store service public URL
+        type: xlrelease.SequentialGroup
+        tasks:
+        - name: Get Store k8s service specs
+          type: xldeploy.Controltask
+          server: XL Deploy
+          numberOfContinueRetrials: 100
+          pollingInterval: 10
+          ciId: Infrastructure/{{$app}}/{{$clusterName}}
+          taskName: describeService
+          variableMapping:
+            pythonScript.xlDeployTaskId: ${taskId}
+            pythonScript.parameters: ${control}
+        - name: Parse Store k8s service
+          type: webhook.XmlWebhook
+          URL: {{.XLDUrlForXLR}}/deployit/tasks/v2/export
+          method: GET
+          username: !value XL_DEPLOY_USERNAME
+          xPathExpression: "/list/task[@id=\"${taskId}\"]//log/text()"
+          variableMapping:
+            pythonScript.result: ${taskOutput}
+            pythonScript.password: ${xld-admin-password}
+        - name: Get Store k8s service ip or hostname
+          type: xlrelease.ScriptTask
+          script: |
+            import re
+            m = re.search('hostname:(.*)\nip:([0-9.]+|None)', releaseVariables['taskOutput'])
+            ipHostname = [m.group(1),m.group(2)]
+            for item in ipHostname:
+                if "None" not in item:
+                    releaseVariables['lbHostnameOrIp'] = item
+          # end of script
+      - name: Check {{$app}} application status
+        type: xlrelease.ScriptTask
+        script: |
+          import urllib2
+          import json
+          import time
+
+          time.sleep(60)
+          token_url = 'http://${lbHostnameOrIp}:8080/jhipster-registry/api/authenticate'
+          instances_url = 'http://${lbHostnameOrIp}:8080/jhipster-registry/api/eureka/applications'
+          values = {"password": "${store-admin-password}",
+                    "rememberMe": "false",
+                    "username": "${store-admin-username}" }
+
+
+          def make_req(url, body=None, token=None):
+              req = urllib2.Request(url, json.dumps(body) if body else None, headers={'Content-type': 'application/json', 'Accept': 'application/json', 'Authorization': 'Bearer %s' % token})
+              opener = urllib2.build_opener()
+              response = opener.open(req)
+              return json.loads(response.read())
+
+          token = make_req(token_url, body=values)['id_token']
+          resp = make_req(instances_url, token=token)
+          if len(resp['applications']) == 4:
+              print "All instances are registered"
+          else:
+              print "Not all instances are registered. Only {0} are registered".format(len(resp['applications']))
+              exit(1)
+        # end of script
+      - name: Verify application
+        type: xlrelease.GateTask
+        team: Release Admin
+        description: |
+          The {{$app}} app is now live on AKS!
+          Check out the web site and complete this task when done.
+
+          URL => http://${lbHostnameOrIp}:8080

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -1,6 +1,6 @@
 {{$app := .AppName | kebabcase}}
 {{$clusterName := .ClusterName | kebabcase}}
-{{$appEnv := .ClusterName | kebabcase}}
+{{$appEnv := printf "azure-aks-%s" $clusterName}}
 apiVersion: xl-release/v1
 kind: Templates
 spec:
@@ -55,8 +55,8 @@ spec:
       - name: Provision Azure AKS cluster
         type: xldeploy.Deploy
         server: XL Deploy
-        deploymentPackage: {{$app}}/AKS-TERRAFORM/{{$app}}-terraform/1.0.0
-        deploymentEnvironment: Environments/{{$app}}/terraform
+        deploymentPackage: {{$app}}/AKS-TERRAFORM/{{$app}}-terraform-aks/1.0.0
+        deploymentEnvironment: Environments/{{$app}}/azure-terraform
     {{end}}
     {{if .enableCICD }}
     - name: Build {{$app}} application
@@ -146,7 +146,7 @@ spec:
           server: XL Deploy
           numberOfContinueRetrials: 100
           pollingInterval: 10
-          ciId: Infrastructure/{{$app}}/{{$clusterName}}
+          ciId: Infrastructure/{{$app}}/azure-aks-{{$clusterName}}
           taskName: describeService
           variableMapping:
             pythonScript.xlDeployTaskId: ${taskId}

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
@@ -1,6 +1,6 @@
 {{$app := .AppName | kebabcase}}
 {{$clusterName := .ClusterName | kebabcase}}
-{{$appEnv := .ClusterName | kebabcase}}
+{{$appEnv := printf "azure-aks-%s" $clusterName}}
 apiVersion: xl-release/v1
 kind: Templates
 spec:
@@ -71,5 +71,5 @@ spec:
       - name: Deprovision Azure AKS cluster
         type: xldeploy.Undeploy
         server: XL Deploy
-        deployedApplication: Environments/{{$app}}/terraform/{{$app}}-terraform
+        deployedApplication: Environments/{{$app}}/gcp-terraform/{{$app}}-terraform-aks
     {{end}}

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
@@ -1,0 +1,75 @@
+{{$app := .AppName | kebabcase}}
+{{$clusterName := .ClusterName | kebabcase}}
+{{$appEnv := .ClusterName | kebabcase}}
+apiVersion: xl-release/v1
+kind: Templates
+spec:
+- name: {{$app}}
+  type: xlrelease.Folder
+  children:
+  - name: {{$app}}-destroy
+    type: xlrelease.Release
+    description: |
+      This XL Release template shows how to undeploy an application, based on microservices architecture, to Azure AKS using XL Deploy and Terraform.
+    tags:
+    - Azure
+    - AKS
+    - {{$app}}
+    scriptUsername: !value XL_RELEASE_USERNAME
+    scriptUserPassword: !value XL_RELEASE_PASSWORD
+    phases:
+    - name: Undeploy Application
+      type: xlrelease.Phase
+      tasks:
+      - name: Undeploy stateless services
+        type: xlrelease.ParallelGroup
+        tasks:
+        - name: Undeploy registry svc
+          type: xldeploy.Undeploy
+          server: XL Deploy
+          deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-registry
+        - name: Undeploy invoice svc
+          type: xldeploy.Undeploy
+          server: XL Deploy
+          deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-invoice
+        - name: Undeploy notification svc
+          type: xldeploy.Undeploy
+          server: XL Deploy
+          deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-notification
+        - name: Undeploy store svc
+          type: xldeploy.Undeploy
+          server: XL Deploy
+          deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-store
+      - name: Undeploy stateful services
+        type: xlrelease.ParallelGroup
+        tasks:
+        - name: Undeploy invoice mysql svc
+          type: xldeploy.Undeploy
+          server: XL Deploy
+          deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-invoice-mysql
+        - name: Undeploy store mysql svc
+          type: xldeploy.Undeploy
+          server: XL Deploy
+          deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-store-mysql
+        - name: Undeploy notification mongodb svc
+          type: xldeploy.Undeploy
+          server: XL Deploy
+          deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-notification-mongodb
+      {{if .ProvisionCluster }}
+      # Un-provision namespace
+      - name: Undeploy {{.Namespace}} namespace
+        type: xldeploy.Undeploy
+        server: XL Deploy
+        deployedApplication: Environments/{{$app}}/{{$appEnv}}/{{$app}}-namespace
+      {{end}}
+    {{if .ProvisionCluster }}
+    # De-provision Infra
+    - name: Deprovision Infrastructure
+      color: '#ff9e3b'
+      type: xlrelease.Phase
+      tasks:
+      - name: Deprovision Azure AKS cluster
+        type: xldeploy.Undeploy
+        server: XL Deploy
+        deployedApplication: Environments/{{$app}}/terraform/{{$app}}-terraform
+    {{end}}


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] The blueprint generates a `docker/docker-compose.yml` file which can be used to spin up the required products that the blueprints uses. This can be used to test and/or try out the blueprint without having to manually install those products.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [x] The Travis CI for the PR is green
- [x] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [x] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [x] The blueprint works on Linux, Mac and Windows.
