### PR TITLE
Added standalone docker-compose configs

### DIFF
--- a/xl-devops-platform/README.md
+++ b/xl-devops-platform/README.md
@@ -1,0 +1,14 @@
+# Docker XL DevOps Platform
+
+Use this blueprint to create:
+* (optional) XL Deploy instance (also JetPack)
+* (optional) XL Release instance (also JetPack)
+* (optional) Docker proxy for deploying containers to Docker itself
+
+## Step 1: Create a directory for the `docker-compose.yaml` file
+
+```plain
+xl blueprint -b /path/to/this/blueprint
+```
+
+Read the generated `xebialabs/USAGE-docker-compose.yaml` file for further instructions.

--- a/xl-devops-platform/__test__/answers-with-xl-release.yaml
+++ b/xl-devops-platform/__test__/answers-with-xl-release.yaml
@@ -1,0 +1,7 @@
+UseXLDeployFlag: true
+XLDeployPort: 4516
+UseXLReleaseFlag: true
+XLReleasePort: 4516
+JetPackOrEnterprise: JetPack
+XLVersion: 8.6.1
+UseDockerProxyFlag: true

--- a/xl-devops-platform/__test__/answers-without-xl-release.yaml
+++ b/xl-devops-platform/__test__/answers-without-xl-release.yaml
@@ -1,0 +1,7 @@
+UseXLDeployFlag: true
+XLDeployPort: 4516
+UseXLReleaseFlag: false
+XLReleasePort: 4516
+JetPackOrEnterprise: JetPack
+XLVersion: 8.6.1
+UseDockerProxyFlag: true

--- a/xl-devops-platform/__test__/test-with-xl-release.yaml
+++ b/xl-devops-platform/__test__/test-with-xl-release.yaml
@@ -1,0 +1,6 @@
+answers-file: answers-with-xl-release.yaml
+expected-files:
+- xebialabs/config.yaml
+- xebialabs/USAGE-docker-compose.md
+- docker/docker-compose.yml
+- docker/data/configure-xl-devops-platform.yaml

--- a/xl-devops-platform/__test__/test-without-xl-release.yaml
+++ b/xl-devops-platform/__test__/test-without-xl-release.yaml
@@ -1,0 +1,7 @@
+answers-file: answers-without-xl-release.yaml
+expected-files:
+- xebialabs/config.yaml
+- xebialabs/USAGE-docker-compose.md
+- docker/docker-compose.yml
+not-expected-files:
+- docker/data/configure-xl-devops-platform.yaml

--- a/xl-devops-platform/blueprint.yaml
+++ b/xl-devops-platform/blueprint.yaml
@@ -1,0 +1,58 @@
+apiVersion: xl/v1
+kind: Blueprint
+
+metadata:
+  projectName: Docker compose
+  description: Creates the necessary `docker-compose.yaml` needed to run your specific setup.
+  author: XebiaLabs
+  version: 1.0
+  instructions: Read xebialabs/USAGE.md to learn how to use this blueprint.
+spec:
+  parameters:
+  - name: UseXLDeployFlag
+    type: Confirm
+    description: Do you want to install XL Deploy?
+    default: true
+
+  - name: XLDeployPort
+    type: Input
+    description: "Host port for XL Deploy:"
+    default: 4516
+    dependsOnTrue: UseXLDeployFlag
+
+  - name: UseXLReleaseFlag
+    type: Confirm
+    description: Do you want to install XL Release?
+    default: true
+
+  - name: XLReleasePort
+    type: Input
+    description: "Host port for XL Release:"
+    default: 5516
+    dependsOnTrue: UseXLReleaseFlag
+
+  - name: JetPackOrEnterprise
+    type: Select
+    description: "Do you want to use JetPack or XL Enterprise:"
+    options:
+    - JetPack
+    - XL Enterprise
+
+  - name: XLVersion
+    type: Select
+    description: "Select the version of XL you want to use:"
+    options:
+    - 8.6.1
+    dependsOnTrue: !expression "UseXLDeployFlag == true || UseXLReleaseFlag == true"
+
+  - name: UseDockerProxyFlag
+    type: Confirm
+    description: Do you want to be able to deploy to your local Docker instance?
+    default: true
+
+  files:
+  - path: xebialabs/USAGE-docker-compose.md.tmpl
+  - path: xebialabs/config.yaml.tmpl
+  - path: docker/docker-compose.yml.tmpl
+  - path: docker/data/configure-xl-devops-platform.yaml.tmpl
+    dependsOnTrue: UseXLReleaseFlag

--- a/xl-devops-platform/docker/data/configure-xl-devops-platform.yaml.tmpl
+++ b/xl-devops-platform/docker/data/configure-xl-devops-platform.yaml.tmpl
@@ -1,0 +1,8 @@
+apiVersion: xl-release/v1
+kind: Templates
+spec:
+- name: XL Deploy
+  type: xldeploy.XLDeployServer
+  url: http://xl-deploy:{{ .XLDeployPort}}
+  username: admin
+  password: admin

--- a/xl-devops-platform/docker/data/configure-xl-devops-platform.yaml.tmpl
+++ b/xl-devops-platform/docker/data/configure-xl-devops-platform.yaml.tmpl
@@ -3,6 +3,6 @@ kind: Templates
 spec:
 - name: XL Deploy
   type: xldeploy.XLDeployServer
-  url: http://xl-deploy:{{ .XLDeployPort}}
+  url: http://xl-deploy:4516
   username: admin
   password: admin

--- a/xl-devops-platform/docker/docker-compose.yml.tmpl
+++ b/xl-devops-platform/docker/docker-compose.yml.tmpl
@@ -1,0 +1,66 @@
+version: '3.7'
+services:
+  {{- if .UseXLDeployFlag }}
+  xl-deploy:
+    {{- if eq .JetPackOrEnterprise "JetPack" }}
+    image: xebialabs/xl-jetpack-deploy:{{ .XLVersion }}
+    {{- else }}
+    image: xebialabs/xl-deploy:{{ .XLVersion }}
+    {{- end }}
+    ports:
+    - "{{.XLDeployPort}}:4516"
+    environment:
+    - ADMIN_PASSWORD=admin
+    - ACCEPT_EULA=Y
+  {{- end }}
+
+  {{- if .UseXLReleaseFlag }}
+  xl-release:
+    {{- if eq .JetPackOrEnterprise "JetPack" }}
+    image: xebialabs/xl-jetpack-release:{{ .XLVersion }}
+    {{- else }}
+    image: xebialabs/xl-release:{{ .XLVersion }}
+    {{- end }}
+    ports:
+    - "{{.XLReleasePort}}:5516"
+    environment:
+    - ADMIN_PASSWORD=admin
+    - ACCEPT_EULA=Y
+  xl-cli:
+    image: xebialabsunsupported/xl-cli:{{ .XLVersion }}
+    depends_on:
+    - xl-deploy
+    - xl-release
+    command: ["apply", "--xl-deploy-url", "http://xl-deploy:{{.XLDeployPort}}/", "--xl-release-url", "http://xl-release:{{.XLReleasePort}}/", "-f", "/data/configure-xl-devops-platform.yaml"]
+    volumes:
+    - ./data/:/data:ro
+  {{- end }}
+
+  {{- if .UseDockerProxyFlag }}
+  dockerproxy:
+    image: tecnativa/docker-socket-proxy:latest
+    privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment: # warning this potentially opens up a security hole :)
+      - AUTH=1
+      - BUILD=1
+      - COMMIT=1
+      - CONTAINERS=1
+      - EVENTS=1
+      - EXEC=1
+      - IMAGES=1
+      - INFO=1
+      - NETWORKS=1
+      - NODES=1
+      - PING=1
+      - PLUGINS=1
+      - POST=1
+      - SECRETS=1
+      - SERVICES=1
+      - SWARM=1
+      - SYSTEM=1
+      - TASKS=1
+      - VERSION=1
+      - VOLUMES=1
+  {{- end }}

--- a/xl-devops-platform/docker/docker-compose.yml.tmpl
+++ b/xl-devops-platform/docker/docker-compose.yml.tmpl
@@ -31,7 +31,7 @@ services:
     depends_on:
     - xl-deploy
     - xl-release
-    command: ["apply", "--xl-deploy-url", "http://xl-deploy:{{.XLDeployPort}}/", "--xl-release-url", "http://xl-release:{{.XLReleasePort}}/", "-f", "/data/configure-xl-devops-platform.yaml"]
+    command: ["apply", "--xl-deploy-url", "http://xl-deploy:4516/", "--xl-release-url", "http://xl-release:5516/", "-f", "/data/configure-xl-devops-platform.yaml"]
     volumes:
     - ./data/:/data:ro
   {{- end }}

--- a/xl-devops-platform/xebialabs/USAGE-docker-compose.md.tmpl
+++ b/xl-devops-platform/xebialabs/USAGE-docker-compose.md.tmpl
@@ -1,0 +1,64 @@
+## Find the apps here:
+{{- if .UseXLDeployFlag }}
+* XL Deploy: http://localhost:{{.XLDeployPort}}
+  * username: admin
+  * password: admin
+{{- end }}
+{{- if .UseXLReleaseFlag }}
+* XL Release: http://localhost:{{.XLReleasePort}}
+  * username: admin
+  * password: admin
+{{- end }}
+
+
+Copy `xebialabs/config.yaml` to `$HOME/.xebialabs` or make sure your `$HOME/.xebialabs/config.yaml` contains:
+
+```plain
+{{- if .UseXLDeployFlag }}
+xl-deploy:
+  authmethod: http
+  password: admin
+  url: http://localhost:{{.XLDeployPort}}/
+  username: admin
+{{- end }}
+{{- if .UseXLReleaseFlag }}
+xl-release:
+  authmethod: http
+  password: admin
+  url: http://localhost:{{.XLReleasePort}}/
+  username: admin
+{{- end }}
+```
+
+If you want to run multiple `docker-compose` instances, you need to give them each unique names.
+
+ Use `docker network list` to see what networks you currently have defined.
+
+```plain
+ docker network list
+ NETWORK ID          NAME                DRIVER              SCOPE
+ abcdef012345        bridge              bridge              local
+ 6789abcdef01        host                host                local
+ 23456789abcd        none                null                local
+ ef0123456789        normal              bridge              local
+ abcdef012345        xebialabs_default   bridge              local
+```
+
+> Here you can see that the `xebialabs` network is already defined.
+
+To use a different network, either use the `--project-name` option or set the `COMPOSE_PROJECT_NAME` environment variable:
+
+```plain
+docker-compose --project-name xebialabs up
+
+# or
+
+export COMPOSE_PROJECT_NAME=xebialabs
+docker-compose up
+```
+
+> **Note:** If you don't do this, all your containers will run under the `xebialabs` network with `xebialabs` prefix.
+>
+> If you only intend to run one container set at a time and run `docker-compose down` in between, you don't have to worry about this.
+
+u

--- a/xl-devops-platform/xebialabs/config.yaml.tmpl
+++ b/xl-devops-platform/xebialabs/config.yaml.tmpl
@@ -1,0 +1,26 @@
+blueprint:
+  current-repository: XL Blueprints
+  repositories:
+  - name: XL Blueprints
+    type: http
+    url: https://dist.xebialabs.com/public/blueprints/
+blueprint-repository:
+  branch: master
+  name: blueprints
+  owner: xebialabs
+  provider: github
+  token: ""
+{{- if .UseXLDeployFlag }}
+xl-deploy:
+  authmethod: http
+  password: admin
+  url: http://localhost:{{.XLDeployPort}}/
+  username: admin
+{{- end }}
+{{- if .UseXLReleaseFlag }}
+xl-release:
+  authmethod: http
+  password: admin
+  url: http://localhost:{{.XLReleasePort}}/
+  username: admin
+{{- end }}


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [x] The Travis CI for the PR is green
- [x] The blueprint has been reviewed by someone else in the team.
- [x] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [x] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [x] The blueprint works on Linux, Mac and Windows.
