### PR TITLE
LOVE-1011 Migrate Existing Blueprints to v2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,11 @@
 
 pipeline {
     agent none
+    parameters {
+        string(name: 'RELEASE_BRANCH_NAME', defaultValue: 'master', description: 'The branch from which to make the release')
+        string(name: 'RELEASE_FOLDER', defaultValue: '', description: 'Folder to copy artifacts into')
+    }
+
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '20', artifactDaysToKeepStr: '7', artifactNumToKeepStr: '5'))
@@ -20,8 +25,10 @@ pipeline {
 
             steps {
                 checkout scm
+                sh "echo 'Release folder: ${params.RELEASE_FOLDER}'"
+                sh "echo 'Release branch: ${params.RELEASE_BRANCH_NAME}'"
                 sh "python ./generate_index.py"
-                sh "rsync -razv --delete --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r --exclude '.git' --exclude '.github' --exclude '.xebialabs' --exclude 'Jenkinsfile' --exclude 'generate_index.py' --exclude 'CONTRIBUTING.md' --exclude 'xl' --exclude 'xlw' --exclude 'integration_tests.py' . ${env.DIST_SERVER_USER}@${env.DIST_SERVER_HOSTNAME}:${env.DIST_SERVER_BLUEPRINT_PATH}"
+                sh "rsync -razv --delete --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r --exclude '.git' --exclude '.github' --exclude '.xebialabs' --exclude 'Jenkinsfile' --exclude 'generate_index.py' --exclude 'CONTRIBUTING.md' --exclude 'xl' --exclude 'xlw' --exclude 'integration_tests.py' --exclude 'Releasefile.groovy' . ${env.DIST_SERVER_USER}@${env.DIST_SERVER_HOSTNAME}:${env.DIST_SERVER_BLUEPRINT_PATH}/${params.RELEASE_FOLDER}"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Every blueprint has a subfolder called `__test__` for CI tests. The tests are ru
 |:-----------------------:|:--------------:|:----------------:|:--------:|:----------------------------------------------------------------------------------:|
 | **answers-file**        | —              | `answers01.yaml` | ✔        | The name of the answers file                                                       |
 | **expected-files**      | Array          | `dir/file01.txt` | -        | Full path of file produced by blueprint                                            |
-| **not-expected-files**  | Array          | `dir/file02.txt` | -        | Full path of file not produced because of `dependsOnTrue` or `dependsOnFalse`      |
+| **not-expected-files**  | Array          | `dir/file02.txt` | -        | Full path of file not produced because of `writeIf`      |
 | **expected-xl-values**  | Dictionary     | `Varname: val`   | -        | Expected values in `values.xlvals`                                                 |
 | **expected-xl-secrets** | Dictionary     | `Varname: val`   | -        | Expected values in `secrets.xlvals`                                                |
 

--- a/Releasefile.groovy
+++ b/Releasefile.groovy
@@ -1,0 +1,90 @@
+// Exported from:        https://xl-release.xebialabs.com/#/templates/Folder4eb254f507564303b486953cfde27482-Releasee11b1a9b619a4ca39114b51900a91987/releasefile
+// XL Release version:   8.6.3
+// Date created:         Fri Jun 07 15:09:04 CEST 2019
+// Needs to be zipped in order to import back into XLR
+
+xlr {
+  template('Blueprints release template') {
+    folder('Cloud Love')
+    variables {
+      stringVariable('BLUEPRINTS_VERSION') {
+        label 'Blueprints Version'
+      }
+      stringVariable('GIT_BRANCH') {
+        label 'Git branch'
+        description 'Git branch to build'
+        value 'master'
+      }
+    }
+    description 'XLR pipeline to release blueprints every milestone'
+    scheduledStartDate Date.parse("yyyy-MM-dd'T'HH:mm:ssZ", '2019-04-08T09:00:00+0200')
+    phases {
+      phase('Verification') {
+        tasks {
+          script('Verify Travis CI last build') {
+            script (['''\
+import urllib2
+import json
+import time
+travis_url = 'https://api.travis-ci.org/repos/xebialabs/blueprints/branches/${GIT_BRANCH}'
+headers = {"User-Agent":"XebiaLabs", "Accept": "application/vnd.travis-ci.2.1+json" }
+def make_req(url, body=None, token=None):
+  req = urllib2.Request(url, None, headers=headers)
+  opener = urllib2.build_opener()
+  response = opener.open(req)
+  return json.loads(response.read())
+resp = make_req(travis_url)
+branch = resp['branch']
+print("\\nLast build #: " + branch['number'])
+print("\\nLast build status: " + branch['state'])
+if branch['state'] != "passed":
+  print("\\nCheck the logs on: https://travis-ci.org/xebialabs/blueprints/builds/" + repo['id'] + "\\n")
+  print(json.dumps(resp, indent=4, sort_keys=True))
+  exit(1)
+'''])
+          }
+        }
+      }
+      phase('Prepare') {
+        color '#0099CC'
+        tasks {
+          custom('Create Branch for release') {
+            script {
+              type 'github.CreateBranch'
+              server 'XebiaLabs GitHub (from community GitHub plugin)'
+              organization 'xebialabs'
+              repositoryName 'blueprints'
+              oldBranch '${GIT_BRANCH}'
+              newBranch '${BLUEPRINTS_VERSION}-maintenance'
+            }
+          }
+        }
+      }
+      phase('Release') {
+        color '#0099CC'
+        tasks {
+          custom('Release new version of Blueprints') {
+            script {
+              type 'jenkins.Build'
+              jenkinsServer 'Jenkins NG'
+              jobName 'XL Devops As Code/job/Blueprints Release'
+              jobParameters 'RELEASE_BRANCH_NAME=${BLUEPRINTS_VERSION}-maintenance\n' +
+              'RELEASE_FOLDER=${BLUEPRINTS_VERSION}'
+            }
+          }
+          custom('Notify team') {
+            script {
+              type 'slack.Notification'
+              server 'Cloud-Love'
+              title 'Blueprints version  ${BLUEPRINTS_VERSION} released'
+              message 'Blueprints version ${BLUEPRINTS_VERSION} was released to https://dist.xebialabs.com/public/blueprints/${BLUEPRINTS_VERSION} and a new branch ${BLUEPRINTS_VERSION}-maintenance has been created in GitHub.'
+              titleLink 'https://dist.xebialabs.com/public/blueprints/${BLUEPRINTS_VERSION}'
+              color 'good'
+            }
+          }
+        }
+      }
+    }
+    
+  }
+}

--- a/aws/basic-eks-cluster/blueprint.yaml
+++ b/aws/basic-eks-cluster/blueprint.yaml
@@ -1,13 +1,13 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  projectName: AWS-EKS-Cluster
+  name: AWS-EKS-Cluster
   description: |
     The blueprint deploys a simple AWS EKS Cluster (with EFS if requested).
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
 
 spec:
@@ -15,60 +15,69 @@ spec:
   # General variables
   - name: AppName
     type: Input
-    description: What is the name of the application? (16 characters max)
-    pattern: ^[a-zA-Z0-9-]{1,16}$
+    prompt: What is the name of the application? (16 characters max)
+    description: Application name will be used to generate cloud resource names
+    validate: !expr "regex('^[a-zA-Z0-9-]{1,16}$', AppName)"
 
   # AWS specific variables
   - name: UseAWSCredentialsFromSystem
     type: Confirm
-    description: Do you want to use AWS credentials from ~/.aws/credentials file?
-    dependsOnTrue: !fn aws.credentials().IsAvailable
+    prompt: Do you want to use AWS credentials from ~/.aws/credentials file?
+    promptIf: !expr "awsCredentials('IsAvailable')"
   - name: AWSAccessKey
-    type: Input
-    secret: true
-    description: What is the AWS Access Key ID?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().AccessKeyID
+    type: SecretInput
+    prompt: What is the AWS Access Key ID?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('AccessKeyID')"
   - name: AWSAccessSecret
-    type: Input
-    secret: true
-    description: What is the AWS Secret Access Key?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().SecretAccessKey
+    type: SecretInput
+    prompt: What is the AWS Secret Access Key?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('SecretAccessKey')"
 
   - name: AWSRegion #options are set manually because EKS service is not registered within AWS GO SDK
     type: Select
-    description: "Select the AWS region:"
+    prompt: "Select the AWS region:"
     options:
     # This needs to be updated in the RegionMap of cloudformation/eks-workers.yaml as well
-      - us-west-2
+      - label: US West (Oregon)
+        value: us-west-2
       # commented out because of https://github.com/boto/boto3/issues/811
       # - us-east-1
-      - us-east-2
-      - eu-central-1
-      # - eu-north-1 # doesn't seem to work
-      - eu-west-1
-      - eu-west-2
-      - eu-west-3
-      - ap-northeast-1
-      - ap-northeast-2
-      - ap-south-1
-      - ap-southeast-1
-      - ap-southeast-2
+      - label: US East (Ohio)
+        value: us-east-2
+      - label: EU (Frankfurt)
+        value: eu-central-1
+      - label: EU (Ireland)
+        value: eu-west-1
+      - label: EU (London)
+        value: eu-west-2
+      - label: EU (Paris)
+        value: eu-west-3
+      - label: Asia Pacific (Tokyo)
+        value: ap-northeast-1
+      - label: Asia Pacific (Seoul)
+        value: ap-northeast-2
+      - label: Asia Pacific (Mumbai)
+        value: ap-south-1
+      - label: Asia Pacific (Singapore)
+        value: ap-southeast-1
+      - label: Asia Pacific (Sydney)
+        value: ap-southeast-2
 
   - name: ClusterName
     type: Input
-    description: What is the name of the cluster?
+    prompt: What is the name of the cluster?
 
   - name: NodeAutoScalingGroupDesiredSize
     type: Input
+    prompt: What is the desired number of nodes in the cluster?
     default: 3
-    description: What is the desired number of nodes in the cluster?
-    pattern: "([0-9])+"
+    validate: !expr "regex('([0-9])+', NodeAutoScalingGroupDesiredSize)"
 
   - name: NodeInstanceType
     type: Select
-    description: What EC2 instance type do you want to use for the nodes?
+    prompt: What EC2 instance type do you want to use for the nodes?
     default: t2.medium
     options:
     - t2.medium
@@ -128,7 +137,7 @@ spec:
 
   - name: ProvisionEFS
     type: Confirm
-    description: "Do you want to provision Amazon Elastic File System?"
+    prompt: "Do you want to provision Amazon Elastic File System?"
     default: false
 
   files:
@@ -144,8 +153,7 @@ spec:
   - path: cloudformation/eks-vpc.yaml
   - path: cloudformation/eks-workers.yaml
   - path: cloudformation/efs.yaml
-    dependsOnTrue: ProvisionEFS
+    writeIf: ProvisionEFS
   - path: xebialabs.yaml
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml
   - path: docker/data/configure-xl-devops-platform.yaml

--- a/aws/datalake/blueprint.yaml
+++ b/aws/datalake/blueprint.yaml
@@ -1,69 +1,81 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: AWS-Datalake
+  name: AWS-Datalake
   description: |
     The blueprint deploys a data lake architecture to AWS using CloudFormation.
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
     Refer to https://docs.aws.amazon.com/solutions/latest/data-lake-solution
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
+  
 spec:
   parameters:
   - name: S3BucketName
-    description: What is the name of the S3 bucket where CloudFormation templates should be saved?
-    default: data-lake
     type: Input
-    pattern: "(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]){3,63}"
+    prompt: What is the name of the S3 bucket where CloudFormation templates should be saved?
+    default: data-lake
+    validate: !expr "regex('(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]){3,63}', S3BucketName)"
   - name: AdministratorName
-    description: What is the name of the Data Lake administrator user?
+    type: Input
+    prompt: What is the name of the Data Lake administrator user?
     default: admin
-    type: Input
-    pattern : ".+"
+    validate: !expr "regex('.+', AdministratorName)"
   - name: AdministratorEmail
-    description: "Provide a valid email address where to send the generated Data Lake administrator credentials:"
+    prompt: "Provide a valid email address where to send the generated Data Lake administrator credentials:"
     type: Input
-    pattern: "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
+    validate: !expr "regex('^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$', AdministratorEmail)"
   - name: CognitoDomain
-    description: "Provide a name for the Cognito service domain (can only contain lower-case letters, numbers, and hyphens):"
+    prompt: "Provide a name for the Cognito service domain (can only contain lower-case letters, numbers, and hyphens):"
     default: data-lake
     type: Input
-    pattern : "[a-z0-9-]+"
+    validate: !expr "regex('[a-z0-9-]+', CognitoDomain)"
   - name: UseAWSCredentialsFromSystem
     type: Confirm
-    description: Do you want to use AWS credentials from ~/.aws/credentials file?
-    dependsOnTrue: !fn aws.credentials().IsAvailable
+    prompt: Do you want to use AWS credentials from ~/.aws/credentials file?
+    promptIf: !expr "awsCredentials('IsAvailable')"
   - name: AWSAccessKey
-    type: Input
-    secret: true
-    description: What is the AWS Access Key ID?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().AccessKeyID
+    type: SecretInput
+    prompt: What is the AWS Access Key ID?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('AccessKeyID')"
   - name: AWSAccessSecret
-    type: Input
-    secret: true
-    description: What is the AWS Secret Access Key?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().SecretAccessKey
+    type: SecretInput
+    prompt: What is the AWS Secret Access Key?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('SecretAccessKey')"
   - name: AWSRegion
     type: Select
-    description: "Select the AWS region:"
-    options:
-      - us-east-2
-      - us-east-1
-      - us-west-2
-      - ap-south-1
-      - ap-northeast-2
-      - ap-southeast-1
-      - ap-southeast-2
-      - ap-northeast-1
-      - ca-central-1
-      - eu-central-1
-      - eu-west-1
-      - eu-west-2
+    saveInXlvals: true
+    prompt: "Select the AWS region:"
     default: us-east-2
-    saveInXlVals: true
+    options:
+      - label: US West (Oregon)
+        value: us-west-2
+      - label: US East (N. Virginia)
+        value: us-east-1
+      - label: US East (Ohio)
+        value: us-east-2
+      - label: EU (Frankfurt)
+        value: eu-central-1
+      - label: EU (Ireland)
+        value: eu-west-1
+      - label: EU (London)
+        value: eu-west-2
+      - label: Canada (Central)
+        value: ca-central-1
+      - label: Asia Pacific (Tokyo)
+        value: ap-northeast-1
+      - label: Asia Pacific (Seoul)
+        value: ap-northeast-2
+      - label: Asia Pacific (Mumbai)
+        value: ap-south-1
+      - label: Asia Pacific (Singapore)
+        value: ap-southeast-1
+      - label: Asia Pacific (Sydney)
+        value: ap-southeast-2
 
   files:
   - path: xebialabs.yaml
@@ -77,6 +89,5 @@ spec:
   - path: xebialabs/xld-infrastructure.yaml.tmpl
   - path: xebialabs/xld-environment.yaml.tmpl
   - path: xebialabs/xlr-pipeline.yaml.tmpl
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml
   - path: docker/data/configure-xl-devops-platform.yaml

--- a/aws/microservice-ecommerce/blueprint.yaml
+++ b/aws/microservice-ecommerce/blueprint.yaml
@@ -1,13 +1,13 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  projectName: AWS-Microservice-EKS-with-JHipster
+  name: AWS-Microservice-EKS-with-JHipster
   description: |
     The blueprint deploys an e-commerce microservice application to AWS EKS.
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
 
 spec:
@@ -15,70 +15,75 @@ spec:
   # General variables
   - name: AppName
     type: Input
-    description: What is the name of the application?
+    prompt: What is the name of the application?
 
   # AWS specific variables
   - name: UseAWSCredentialsFromSystem
     type: Confirm
-    description: Do you want to use AWS credentials from ~/.aws/credentials file?
-    dependsOnTrue: !fn aws.credentials().IsAvailable
+    prompt: Do you want to use AWS credentials from ~/.aws/credentials file?
+    promptIf: !expr "awsCredentials('IsAvailable')"
   - name: AWSAccessKey
-    type: Input
-    secret: true
-    description: What is the AWS Access Key ID?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().AccessKeyID
+    type: SecretInput
+    prompt: What is the AWS Access Key ID?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('AccessKeyID')"
   - name: AWSAccessSecret
-    type: Input
-    secret: true
-    description: What is the AWS Secret Access Key?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().SecretAccessKey
+    type: SecretInput
+    prompt: What is the AWS Secret Access Key?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('SecretAccessKey')"
   - name: AWSRegion #options are set manually because EKS service is not registered within AWS GO SDK
     type: Select
-    description: "Select the AWS region:"
+    prompt: "Select the AWS region:"
     options:
     # This needs to be updated in the RegionMap of cloudformation/eks-workers.yaml as well
-      - us-west-2
+      - label: US West (Oregon)
+        value: us-west-2
       # commented out because of https://github.com/boto/boto3/issues/811
       # - us-east-1
-      - us-east-2
-      - eu-central-1
+      - label: US East (Ohio)
+        value: us-east-2
+      - label: EU (Frankfurt)
+        value: eu-central-1
       # - eu-north-1 # doesn't seem to work
-      - eu-west-1
-      - eu-west-2
-      - eu-west-3
-      - ap-northeast-1
-      - ap-northeast-2
-      - ap-south-1
-      - ap-southeast-1
-      - ap-southeast-2
+      - label: EU (Ireland)
+        value: eu-west-1
+      - label: EU (London)
+        value: eu-west-2
+      - label: EU (Paris)
+        value: eu-west-3
+      - label: Asia Pacific (Tokyo)
+        value: ap-northeast-1
+      - label: Asia Pacific (Seoul)
+        value: ap-northeast-2
+      - label: Asia Pacific (Mumbai)
+        value: ap-south-1
+      - label: Asia Pacific (Singapore)
+        value: ap-southeast-1
+      - label: Asia Pacific (Sydney)
+        value: ap-southeast-2
   - name: ProvisionCluster
     type: Confirm
-    description: Do you want to provision a new AWS EKS cluster?
+    prompt: Do you want to provision a new AWS EKS cluster?
   - name: ClusterName
     type: Input
-    description: What is the name of the cluster?
+    prompt: What is the name of the cluster?
   - name: ClusterEndpoint
     type: Input
-    dependsOnFalse: ProvisionCluster
-    description: What is the endpoint for the cluster, example https://3219568049031C127A97DD725F241767.yl4.eu-west-1.eks.amazonaws.com
+    prompt: What is the endpoint for the cluster, example https://3219568049031C127A97DD725F241767.yl4.eu-west-1.eks.amazonaws.com
+    promptIf: !expr "!ProvisionCluster"
   - name: Namespace
     type: Input
-    dependsOnFalse: ProvisionCluster
-    description: What is the name of the namespace? This should be same as the one used in Kubernetes files.
+    prompt: What is the name of the namespace? This should be same as the one used in Kubernetes files.
+    promptIf: !expr "!ProvisionCluster"
     default: xl-demo
   - name: StoreAdminUsername
-    type: Input
-    description: Store Admin username
     value: admin
   - name: StoreAdminPassword
-    type: Input
-    description: Store Admin password
     value: admin
   - name: XLDUrlForXLR
     type: Input
-    description: XL Deploy URL for XL Release (This will only be used in the XL Release template)
+    prompt: XL Deploy URL for XL Release (This will only be used in the XL Release template)
     default: http://xl-deploy:4516
 
   files:
@@ -91,19 +96,18 @@ spec:
   - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl
   - path: xebialabs/USAGE.md.tmpl
   - path: kubernetes/aws-auth-cm.yaml
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: cloudformation/cfn-secret-provider.zip
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: cloudformation/eks-master.yaml
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: cloudformation/eks-user.yaml
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: cloudformation/eks-vpc.yaml
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: cloudformation/eks-workers.yaml
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: xebialabs.yaml
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml
   - path: docker/data/configure-xl-devops-platform.yaml
   - path: docker/jenkins/jenkins.yaml

--- a/aws/monolith-terraform/blueprint.yaml
+++ b/aws/monolith-terraform/blueprint.yaml
@@ -1,51 +1,49 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: AWS-Terraform-Monolith-ECS-Fargate
+  name: AWS-Terraform-Monolith-ECS-Fargate
   description: |
     The blueprint deploys a monolithic application generated with JHipster, to AWS ECS with the Fargate launch type.
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
+
 spec:
   parameters:
   - name: AppName
     type: Input
-    description: What is the Application name (maximum 25 characters)?
-    pattern: "(\\S){0,25}"
+    prompt: What is the Application name (maximum 25 characters)?
+    validate: !expr "regex('(\\\\S){0,25}', AppName)"
   - name: PublicPort
-    type: Input
-    description: At what port should the application be exposed?
+    description: The port that the application shoule be exposed
     value: 80
   - name: MySQLMasterPassword
-    type: Input
-    description: What should be the password for MySQL? (minimum 8 characters)
-    pattern: "(\\S){8,}"
-    secret: true
+    type: SecretInput
+    prompt: What should be the password for MySQL? (minimum 8 characters)
+    validate: !expr "regex('(\\\\S){8,}', MySQLMasterPassword)"
   - name: UseAWSCredentialsFromSystem
     type: Confirm
-    description: Do you want to use AWS credentials from ~/.aws/credentials file?
-    dependsOnTrue: !fn aws.credentials().IsAvailable
+    prompt: Do you want to use AWS credentials from ~/.aws/credentials file?
+    promptIf: !expr "awsCredentials('IsAvailable')"
   - name: AWSAccessKey
-    type: Input
-    secret: true
-    description: What is the AWS Access Key ID?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().AccessKeyID
+    type: SecretInput
+    prompt: What is the AWS Access Key ID?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('AccessKeyID')"
   - name: AWSAccessSecret
-    type: Input
-    secret: true
-    description: What is the AWS Secret Access Key?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().SecretAccessKey
+    type: SecretInput
+    prompt: What is the AWS Secret Access Key?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('SecretAccessKey')"
   - name: AWSRegion
-    saveInXlVals: true
     type: Select
-    description: "Select the AWS region:"
+    prompt: "Select the AWS region:"
+    saveInXlvals: true
+    default: !expr "awsRegions('ecs', 0)"
     options:
-      - !fn aws.regions(ecs)
-    default: !fn aws.regions(ecs)[0]
+      - !expr "awsRegions('ecs')"
 
   files:
   - path: xebialabs/xld-environment.yaml.tmpl
@@ -57,6 +55,5 @@ spec:
   - path: terraform/infrastructure/infrastructure.tf
   - path: terraform/infrastructure/outputs.tf
   - path: terraform/infrastructure/variables.tf
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml
   - path: docker/data/configure-xl-devops-platform.yaml

--- a/aws/monolith/blueprint.yaml
+++ b/aws/monolith/blueprint.yaml
@@ -1,50 +1,47 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: AWS-Monolith-ECS-Fargate
+  name: AWS-Monolith-ECS-Fargate
   description: |
     The blueprint deploys a monolithic application generated with JHipster, to AWS ECS with the Fargate launch type.
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
+  
 spec:
   parameters:
   - name: AppName
     type: Input
-    description: What is the Application name (maximum 25 characters)?
-    pattern: "(\\S){0,25}"
+    prompt: What is the Application name (maximum 25 characters)?
+    validate: !expr "regex('(\\\\S){0,25}', AppName)"
   - name: PublicPort
-    type: Input
-    description: At what port should the application be exposed?
     value: 80
   - name: MySQLMasterPassword
-    type: Input
-    description: What should be the password for MySQL? (minimum 8 characters)
-    secret: true
+    type: SecretInput
+    prompt: What should be the password for MySQL? (minimum 8 characters)
   - name: UseAWSCredentialsFromSystem
     type: Confirm
-    description: Do you want to use AWS credentials from ~/.aws/credentials file?
-    dependsOnTrue: !fn aws.credentials().IsAvailable
+    prompt: Do you want to use AWS credentials from ~/.aws/credentials file?
+    promptIf: !expr "awsCredentials('IsAvailable')"
   - name: AWSAccessKey
-    type: Input
-    secret: true
-    description: What is the AWS Access Key ID?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().AccessKeyID
+    type: SecretInput
+    prompt: What is the AWS Access Key ID?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('AccessKeyID')"
   - name: AWSAccessSecret
-    type: Input
-    secret: true
-    description: What is the AWS Secret Access Key?
-    dependsOnFalse: UseAWSCredentialsFromSystem
-    default: !fn aws.credentials().SecretAccessKey
+    type: SecretInput
+    prompt: What is the AWS Secret Access Key?
+    promptIf: !expr "!UseAWSCredentialsFromSystem"
+    default: !expr "awsCredentials('SecretAccessKey')"
   - name: AWSRegion
-    saveInXlVals: true
     type: Select
-    description: "Select the AWS region:"
+    prompt: "Select the AWS region:"
+    saveInXlvals: true
+    default: !expr "awsRegions('ecs', 0)"
     options:
-      - !fn aws.regions(ecs)
-    default: !fn aws.regions(ecs)[0]
+      - !expr "awsRegions('ecs')"
 
   files:
   - path: xebialabs/xld-infrastructure.yaml.tmpl
@@ -53,6 +50,5 @@ spec:
   - path: xebialabs/xlr-pipeline.yaml.tmpl
   - path: xebialabs/USAGE.md.tmpl
   - path: xebialabs.yaml
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml
   - path: docker/data/configure-xl-devops-platform.yaml

--- a/aws/monolith/blueprint.yaml
+++ b/aws/monolith/blueprint.yaml
@@ -17,10 +17,12 @@ spec:
     prompt: What is the Application name (maximum 25 characters)?
     validate: !expr "regex('(\\\\S){0,25}', AppName)"
   - name: PublicPort
+    description: The port that the application shoule be exposed
     value: 80
   - name: MySQLMasterPassword
     type: SecretInput
     prompt: What should be the password for MySQL? (minimum 8 characters)
+    validate: !expr "regex('(\\\\S){8,}', MySQLMasterPassword)"
   - name: UseAWSCredentialsFromSystem
     type: Confirm
     prompt: Do you want to use AWS credentials from ~/.aws/credentials file?

--- a/azure/basic-aks-cluster/blueprint.yaml
+++ b/azure/basic-aks-cluster/blueprint.yaml
@@ -1,12 +1,12 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  projectName: Azure-AKS-Basic
+  name: Azure-AKS-Basic
   description: |
     The blueprint provisions a very basic Azure AKS cluster. XL Deploy does the provisioning.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE-azure-basic-aks-cluster.md" for further usage instructions.
 
 spec:
@@ -16,72 +16,102 @@ spec:
   # ############################################################################
   - name: ClientID
     type: Input
-    description: What is the client id (appId) of an existing Service Principal in Azure?
+    prompt: What is the client id (appId) of an existing Service Principal in Azure?
 
   - name: ClientSecret
-    type: Input
-    description: What is the secret (password) for that client id?
-    secret: true
+    type: SecretInput
+    prompt: What is the secret (password) for that client id?
 
   - name: SubscriptionID
     type: Input
-    description: What is your existing Azure subscription id?
+    prompt: What is your existing Azure subscription id?
 
   - name: TenantID
     type: Input
-    description: What is your existing Azure tenant id?
+    prompt: What is your existing Azure tenant id?
 
   # ############################################################################
   # Resource group under which the cluster will be created
   # ############################################################################
   - name: ResourceGroup
     type: Input
-    description: What do you want to name the resource group?
+    prompt: What do you want to name the resource group?
 
   - name: ResourceGroupLocation
     type: Select
-    description: "Select where this resource group will go:"
+    prompt: "Select where this resource group will go:"
     options:
-    - eastasia
-    - southeastasia
-    - centralus
-    - eastus
-    - eastus2
-    - westus
-    - northcentralus
-    - southcentralus
-    - northeurope
-    - westeurope
-    - japanwest
-    - japaneast
-    - brazilsouth
-    - australiaeast
-    - australiasoutheast
-    - southindia
-    - centralindia
-    - westindia
-    - canadacentral
-    - canadaeast
-    - uksouth
-    - ukwest
-    - westcentralus
-    - westus2
-    - koreacentral
-    - koreasouth
-    - francecentral
-    - francesouth
-    - australiacentral
-    - australiacentral2
-    - southafricanorth
-    - southafricawest
+      - label: East Asia
+        value: eastasia
+      - label: Southeast Asia
+        value: southeastasia
+      - label: Central US
+        value: centralus
+      - label: East US
+        value: eastus
+      - label: East US 2
+        value: eastus2
+      - label: West US
+        value: westus
+      - label: North Central US
+        value: northcentralus
+      - label: South Central US
+        value: southcentralus
+      - label: North Europe
+        value: northeurope
+      - label: West Europe
+        value: westeurope
+      - label: Japan West
+        value: japanwest
+      - label: Japan East
+        value: japaneast
+      - label: Brazil South
+        value: brazilsouth
+      - label: Australia East
+        value: australiaeast
+      - label: Australia Southeast
+        value: australiasoutheast
+      - label: South India
+        value: southindia
+      - label: Central India
+        value: centralindia
+      - label: West India
+        value: westindia
+      - label: Canada Central
+        value: canadacentral
+      - label: Canada East
+        value: canadaeast
+      - label: UK South
+        value: uksouth
+      - label: UK West
+        value: ukwest
+      - label: West Central US
+        value: westcentralus
+      - label: West US 2
+        value: westus2
+      - label: Korea Central
+        value: koreacentral
+      - label: Korea South
+        value: koreasouth
+      - label: France Central
+        value: francecentral
+      - label: France South
+        value: francesouth
+      - label: Australia Central
+        value: australiacentral
+      - label: Australia Central 2
+        value: australiacentral2
+      - label: South Africa North
+        value: southafricanorth
+      - label: South Africa West
+        value: southafricawest
 
   - name: ClusterName
     type: Input
-    description: What do you want to name the cluster?
+    prompt: What do you want to name the cluster?
 
   # Hidden prefix
   - name: Prefix
-    type: Input
     value: azure-aks-
 
   files:

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -1,38 +1,37 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  projectName: Azure-Microservice-AKS-with-JHipster
+  name: Azure-Microservice-AKS-with-JHipster
   description: |
     The blueprint deploys an e-commerce microservice application to Azure AKS.
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
 
 spec:
   parameters:
   - name: AppName
     type: Input
-    description: What do you want to name the application?
+    prompt: What do you want to name the application?
 
   - name: ProvisionCluster
     type: Confirm
-    description: Do you want to provision a new Azure AKS cluster?
+    prompt: Do you want to provision a new Azure AKS cluster?
 
   # ############################################################################
   # Own cluster
   # ############################################################################
   - name: ClusterEndpoint
     type: Input
-    description: What is the endpoint for the existing cluster, example https://104.155.109.230
-    dependsOnTrue: !expression "!ProvisionCluster"
+    prompt: What is the endpoint for the existing cluster, example https://104.155.109.230
+    promptIf: !expr "!ProvisionCluster"
 
   - name: PasswordToken
-    type: Input
-    description: What is the token for accessing the existing cluster
-    dependsOnTrue: !expression "!ProvisionCluster"
-    secret: true
+    type: SecretInput
+    prompt: What is the token for accessing the existing cluster
+    promptIf: !expr "!ProvisionCluster"
   # ############################################################################
 
   # ############################################################################
@@ -40,65 +39,96 @@ spec:
   # ############################################################################
   - name: AKSRegion
     type: Select
-    description: "Select the AKS region for the cluster:"
-    dependsOnTrue: ProvisionCluster
+    prompt: "Select the AKS region for the cluster:"
+    promptIf: ProvisionCluster
     options:
-    - eastasia
-    - southeastasia
-    - centralus
-    - eastus
-    - eastus2
-    - westus
-    - northcentralus
-    - southcentralus
-    - northeurope
-    - westeurope
-    - japanwest
-    - japaneast
-    - brazilsouth
-    - australiaeast
-    - australiasoutheast
-    - southindia
-    - centralindia
-    - westindia
-    - canadacentral
-    - canadaeast
-    - uksouth
-    - ukwest
-    - westcentralus
-    - westus2
-    - koreacentral
-    - koreasouth
-    - francecentral
-    - francesouth
-    - australiacentral
-    - australiacentral2
-    - southafricanorth
-    - southafricawest
+      - label: East Asia
+        value: eastasia
+      - label: Southeast Asia
+        value: southeastasia
+      - label: Central US
+        value: centralus
+      - label: East US
+        value: eastus
+      - label: East US 2
+        value: eastus2
+      - label: West US
+        value: westus
+      - label: North Central US
+        value: northcentralus
+      - label: South Central US
+        value: southcentralus
+      - label: North Europe
+        value: northeurope
+      - label: West Europe
+        value: westeurope
+      - label: Japan West
+        value: japanwest
+      - label: Japan East
+        value: japaneast
+      - label: Brazil South
+        value: brazilsouth
+      - label: Australia East
+        value: australiaeast
+      - label: Australia Southeast
+        value: australiasoutheast
+      - label: South India
+        value: southindia
+      - label: Central India
+        value: centralindia
+      - label: West India
+        value: westindia
+      - label: Canada Central
+        value: canadacentral
+      - label: Canada East
+        value: canadaeast
+      - label: UK South
+        value: uksouth
+      - label: UK West
+        value: ukwest
+      - label: West Central US
+        value: westcentralus
+      - label: West US 2
+        value: westus2
+      - label: Korea Central
+        value: koreacentral
+      - label: Korea South
+        value: koreasouth
+      - label: France Central
+        value: francecentral
+      - label: France South
+        value: francesouth
+      - label: Australia Central
+        value: australiacentral
+      - label: Australia Central 2
+        value: australiacentral2
+      - label: South Africa North
+        value: southafricanorth
+      - label: South Africa West
+        value: southafricawest
 
     # ############################################################################
   # Authentication
   # ############################################################################
   - name: SubscriptionID
     type: Input
-    description: "Enter you Azure subscription id:"
-    dependsOnTrue: ProvisionCluster
+    prompt: "Enter you Azure subscription id:"
+    promptIf: ProvisionCluster
 
   - name: TenantID
     type: Input
-    description: "Enter your Azure tenant id:"
-    dependsOnTrue: ProvisionCluster
+    prompt: "Enter your Azure tenant id:"
+    promptIf: ProvisionCluster
 
   - name: ClientID
     type: Input
-    description: "Enter your Azure client id:"
-    dependsOnTrue: ProvisionCluster
+    prompt: "Enter your Azure client id:"
+    promptIf: ProvisionCluster
 
   - name: ClientSecret
-    type: Input
-    description: "Enter your Azure client secret:"
-    secret: true
-    dependsOnTrue: ProvisionCluster
+    type: SecretInput
+    prompt: "Enter your Azure client secret:"
+    promptIf: ProvisionCluster
 
   # ############################################################################
   # For the Terraform backend storage
@@ -106,40 +136,38 @@ spec:
   - name: ResourceGroup
     # Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period
     type: Input
-    description: "The blueprint will create a new Resource Group for the cluster. Please supply a name:"
-    pattern: "[\\w._()-]{2,50}[\\w_()-]"
-    dependsOnTrue: ProvisionCluster
+    prompt: "The blueprint will create a new Resource Group for the cluster. Please supply a name:"
+    promptIf: ProvisionCluster
+    validate: !expr "regex('[\\\\w._()-]{2,50}[\\\\w_()-]', ResourceGroup)"
 
   - name: StorageAccountName
     type: Input
-    description: "Enter the Storage Account where Terraform will store its state (see README.md step 3.2):"
-    dependsOnTrue: ProvisionCluster
+    prompt: "Enter the Storage Account where Terraform will store its state (see README.md step 3.2):"
+    promptIf: ProvisionCluster
 
   - name: StorageAccessKey
     type: Input
-    description: "Enter the Storage Account key for accessing the storage (see README.md step 3.3):"
-    dependsOnTrue: ProvisionCluster
+    prompt: "Enter the Storage Account key for accessing the storage (see README.md step 3.3):"
+    promptIf: ProvisionCluster
 
   - name: StorageContainerName
     type: Input
-    description: "Enter the Storage Container name (see README.md step 3.4):"
+    prompt: "Enter the Storage Container name (see README.md step 3.4):"
+    promptIf: ProvisionCluster
     default: terraform-state
-    dependsOnTrue: ProvisionCluster
   # ############################################################################
 
   - name: ClusterName
     type: Input
-    description: What name do you want to give the cluster?
-    pattern: "[a-zA-Z][\\w-]{1,29}[\\w]"
-    # dependsOnTrue: ProvisionCluster
+    prompt: What name do you want to give the cluster?
+    validate: !expr "regex('[a-zA-Z][\\\\w-]{1,29}[\\\\w]', ClusterName)"
 
   - name: Namespace
-    type: Input
     value: xl-demo
 
   - name: XLDUrlForXLR
     type: Input
-    description: XL Deploy URL for XL Release (This will only be used in the XL Release template)
+    prompt: XL Deploy URL for XL Release (This will only be used in the XL Release template)
     default: http://xl-deploy:4516
 
   # ############################################################################
@@ -147,18 +175,14 @@ spec:
   # ############################################################################
   - name: enableCICD
     type: Confirm
-    description: Do you want to enable CI/CD integration with Jenkins?
+    prompt: Do you want to enable CI/CD integration with Jenkins?
 
   - name: StoreAdminUsername
-    type: Input
-    description: Store Admin username
     value: admin
 
   - name: StoreAdminPassword
-    type: Input
-    description: Store Admin password
+    type: SecretInput
     value: admin
-    secret: true
   # ############################################################################
 
   files:
@@ -174,29 +198,29 @@ spec:
   - path: xebialabs/USAGE.md.tmpl
   # Terraform
   - path: terraform/main.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/variables.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/backend.tf.tmpl
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/outputs.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/.gitignore
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/aks/main.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/aks/variables.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/aks/outputs.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/vpc/main.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/vpc/variables.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/vpc/outputs.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   # docker-compose setup for required tools
   - path: docker/docker-compose.yml.tmpl
   - path: docker/data/configure-xl-devops-platform.yaml
   - path: docker/jenkins/jenkins.yaml
-    dependsOnTrue: enableCICD
+    writeIf: enableCICD

--- a/devsecops/security-scanning/blueprint.yaml
+++ b/devsecops/security-scanning/blueprint.yaml
@@ -1,139 +1,137 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: Security and Compliance Demo Application
+  name: Security and Compliance Demo Application
   description: |
     The blueprint creates a simple template to orchestrate Security and Compliance with XL Release.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
+
 spec:
   parameters:
   - name: AppName
     type: Input
-    description: What is the name of the Application?
+    prompt: What is the name of the Application?
   - name: ConfigureSonar
     type: Confirm
-    description: Do you want to configure SonarQube in your compliance pipeline?
+    prompt: Do you want to configure SonarQube in your compliance pipeline?
   - name: SonarUrl
     type: Input
-    dependsOnTrue: ConfigureSonar
-    description: What is the URL for SonarQube, example https://sonarcloud.io?
+    prompt: What is the URL for SonarQube, example https://sonarcloud.io?
+    promptIf: ConfigureSonar
     default: https://sonarcloud.io
   - name: ConfigureSonarUsername
     type: Confirm
-    dependsOnTrue: ConfigureSonar
-    description: Do you want to enter an username for SonarQube?
+    prompt: Do you want to enter an username for SonarQube?
+    promptIf: ConfigureSonar
   - name: SonarUsername
     type: Input
-    dependsOnTrue: ConfigureSonarUsername
-    description: What is the username for SonarQube?
-    saveInXlVals: true
+    prompt: What is the username for SonarQube?
+    promptIf: ConfigureSonarUsername
+    saveInXlvals: true
     default: ""
   - name: ConfigureSonarPassword
     type: Confirm
-    dependsOnTrue: ConfigureSonar
-    description: Do you want to enter a password for SonarQube?
+    prompt: Do you want to enter a password for SonarQube?
+    promptIf: ConfigureSonar
   - name: SonarPassword
-    type: Input
-    secret: true
-    dependsOnTrue: ConfigureSonarPassword
-    description: What is the password for SonarQube?
+    type: SecretInput
+    prompt: What is the password for SonarQube?
+    promptIf: ConfigureSonarPassword
     default: ""
   - name: SonarResource
     type: Input
-    dependsOnTrue: ConfigureSonar
-    description: What is the project key for SonarQube?
+    prompt: What is the project key for SonarQube?
+    promptIf: ConfigureSonar
   - name: ConfigureFortify
     type: Confirm
-    description: Do you want to configure Fortify in your compliance pipeline?
+    prompt: Do you want to configure Fortify in your compliance pipeline?
   - name: SelectedFortify
     type: Select
-    description: "Select the Source Code Analysis Tool:"
+    prompt: "Select the Source Code Analysis Tool:"
+    promptIf: ConfigureFortify
+    default: Fortify SSC
     options:
       - Fortify SSC
       - Fortify on Demand
-    default: Fortify SSC
-    dependsOnTrue: ConfigureFortify
   - name: FortifyUrl
     type: Input
-    dependsOnTrue: ConfigureFortify
-    description: What is the URL for Fortify, example https://api.emea.fortify.com?
+    prompt: What is the URL for Fortify, example https://api.emea.fortify.com?
+    promptIf: ConfigureFortify
     default: https://api.emea.fortify.com
   - name: FortifyUsername
     type: Input
-    dependsOnTrue: ConfigureFortify
-    description: What is the username for Fortify?
+    prompt: What is the username for Fortify?
+    promptIf: ConfigureFortify
   - name: FortifyPassword
-    type: Input
-    secret: true
-    dependsOnTrue: ConfigureFortify
-    description: What is the password for Fortify?
+    type: SecretInput
+    prompt: What is the password for Fortify?
+    promptIf: ConfigureFortify
   - name: FortifyApplication
     type: Input
-    dependsOnTrue: ConfigureFortify
-    description: What is the application name for Fortify?
+    prompt: What is the application name for Fortify?
+    promptIf: ConfigureFortify
   - name: FortifyApplicationVersion
     type: Input
-    dependsOnTrue: ConfigureFortify
-    description: What is the application version for Fortify?
+    prompt: What is the application version for Fortify?
+    promptIf: ConfigureFortify
   - name: ConfigureCheckmarx
     type: Confirm
-    description: Do you want to configure Checkmarx in your compliance pipeline?
+    prompt: Do you want to configure Checkmarx in your compliance pipeline?
   - name: SelectedCheckmarx
     type: Select
-    description: "Select the compliance you want to configure:"
+    prompt: "Select the compliance you want to configure:"
+    promptIf: ConfigureCheckmarx
+    default: both
     options:
       - CxSAST
       - CxOSA
       - both
-    default: both
-    dependsOnTrue: ConfigureCheckmarx
   - name: CheckmarxUrl
     type: Input
-    dependsOnTrue: ConfigureCheckmarx
-    description: What is the URL for Checkmarx?
+    prompt: What is the URL for Checkmarx?
+    promptIf: ConfigureCheckmarx
   - name: CheckmarxUsername
     type: Input
-    dependsOnTrue: ConfigureCheckmarx
-    description: What is the username for Checkmarx?
+    prompt: What is the username for Checkmarx?
+    promptIf: ConfigureCheckmarx
   - name: CheckmarxPassword
-    type: Input
-    secret: true
-    dependsOnTrue: ConfigureCheckmarx
-    description: What is the password for Checkmarx?
+    type: SecretInput
+    prompt: What is the password for Checkmarx?
+    promptIf: ConfigureCheckmarx
   - name: CheckmarxApplication
     type: Input
-    dependsOnTrue: ConfigureCheckmarx
-    description: What is the project name for Checkmarx?
+    prompt: What is the project name for Checkmarx?
+    promptIf: ConfigureCheckmarx
   - name: CheckmarxTeam
     type: Input
-    dependsOnTrue: ConfigureCheckmarx
-    description: What is the team name for Checkmarx?
+    prompt: What is the team name for Checkmarx?
+    promptIf: ConfigureCheckmarx
   - name: ConfigureBlackduck
     type: Confirm
-    description: Do you want to configure Black Duck in your compliance pipeline?
+    prompt: Do you want to configure Black Duck in your compliance pipeline?
   - name: BlackduckUrl
     type: Input
-    dependsOnTrue: ConfigureBlackduck
-    description: What is the URL for Black Duck?
+    prompt: What is the URL for Black Duck?
+    promptIf: ConfigureBlackduck
   - name: BlackduckUsername
     type: Input
-    dependsOnTrue: ConfigureBlackduck
-    description: What is the username for Black Duck?
+    prompt: What is the username for Black Duck?
+    promptIf: ConfigureBlackduck
   - name: BlackduckPassword
-    type: Input
-    secret: true
-    dependsOnTrue: ConfigureBlackduck
-    description: What is the password for Black Duck?
+    type: SecretInput
+    prompt: What is the password for Black Duck?
+    promptIf: ConfigureBlackduck
   - name: BlackduckApplication
     type: Input
-    dependsOnTrue: ConfigureBlackduck
-    description: What is the application name for Black Duck?
+    prompt: What is the application name for Black Duck?
+    promptIf: ConfigureBlackduck
   - name: BlackduckApplicationVersion
     type: Input
-    dependsOnTrue: ConfigureBlackduck
-    description: What is the application version for Black Duck?
+    prompt: What is the application version for Black Duck?
+    promptIf: ConfigureBlackduck
 
   files:
   - path: xebialabs/xlr-configuration.yaml.tmpl
@@ -141,5 +139,4 @@ spec:
   - path: xebialabs/xlr-dashboard.yaml.tmpl
   - path: xebialabs/USAGE.md.tmpl
   - path: xebialabs.yaml
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml

--- a/docker/application/blueprint.yaml
+++ b/docker/application/blueprint.yaml
@@ -1,36 +1,39 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: Deploy a single container to Docker
+  name: Deploy a single container to Docker
   description: |
     This blueprint defines an application for a single Docker container
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Read xebialabs/USAGE-docker-application.md to learn how to use this blueprint.
+
 spec:
   parameters:
   - name: DockerImageRepository
     type: Input
+    prompt: What is the Docker image repository?
     default: nginx
-    description: What is the Docker image repository?
   - name: DockerImageTag
     type: Input
-    description: What is the Docker image tag?
+    prompt: What is the Docker image tag?
     default: latest
   - name: ExposePort
     type: Confirm
-    description: Should the Docker container expose a port?
+    prompt: Should the Docker container expose a port?
     default: true
   - name: ContainerPort
     type: Input
-    dependsOnTrue: ExposePort
-    description: What is the container port to expose?
+    prompt: What is the container port to expose?
+    promptIf: ExposePort
     default: 80
   - name: HostPort
     type: Input
-    dependsOnTrue: ExposePort
-    description: At which host port should that port be exposed?
+    prompt: At which host port should that port be exposed?
+    promptIf: ExposePort
     default: 8080
+    
   files:
   - path: xebialabs/docker-application.yaml.tmpl
   - path: xebialabs/USAGE-docker-application.md

--- a/docker/environment/blueprint.yaml
+++ b/docker/environment/blueprint.yaml
@@ -1,18 +1,20 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: Create infrastructure and environment for Docker
+  name: Create infrastructure and environment for Docker
   description: |
     This blueprint defines an environment to which Docker containers can be deployed
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Read xebialabs/USAGE-docker-environment.md to learn how to use this blueprint.
+
 spec:
   parameters:
   - name: DockerURL
     type: Input
+    prompt: What is the URL of the Docker engine?
     default: http://dockerproxy:2375
-    description: What is the URL of the Docker engine?
 
   files:
   - path: xebialabs/docker-environment.yaml.tmpl

--- a/docker/simple-demo-app/blueprint.yaml
+++ b/docker/simple-demo-app/blueprint.yaml
@@ -1,33 +1,35 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: Docker Demo Application
+  name: Docker Demo Application
   description: |
     The blueprint deploys a simple application in 2 Docker containers into your local Docker setup.
     XL Deploy does the deployment, while XL Release orchestrates everything.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
+
 spec:
   parameters:
   - name: AppName
     type: Input
-    description: What is the Application name?
+    prompt: What is the Application name?
   - name: ContainerPort
     type: Input
-    description: At what port should the application be exposed in the container?
+    prompt: At what port should the application be exposed in the container?
     default: 80
   - name: HostPort
     type: Input
-    description: At what port should the container port be mapped in the host?
+    prompt: At what port should the container port be mapped in the host?
     default: 8181
   - name: BackendDockerImage
     type: Input
-    description: What is the Docker Image (repo and path) for the Backend service?
+    prompt: What is the Docker Image (repo and path) for the Backend service?
     default: xebialabsunsupported/rest-o-rant-api
   - name: FrontendDockerImage
     type: Input
-    description: What is the Docker Image (repo and path) for the Frontend service?
+    prompt: What is the Docker Image (repo and path) for the Frontend service?
     default: xebialabsunsupported/rest-o-rant-web
 
   files:
@@ -36,6 +38,5 @@ spec:
   - path: xebialabs/xlr-pipeline.yaml.tmpl
   - path: xebialabs/USAGE.md.tmpl
   - path: xebialabs.yaml
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml
   - path: docker/data/configure-xl-devops-platform.yaml

--- a/gcp/basic-gke-cluster/blueprint.yaml
+++ b/gcp/basic-gke-cluster/blueprint.yaml
@@ -1,92 +1,109 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  projectName: GKE-Cluster
+  name: GKE-Cluster
   description: |
     The blueprint provisions a GCP GKE Cluster using Terraform and XL Deploy.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Read xebialabs/USAGE-gcp-basic-gke-cluster.md to learn how to use this blueprint.
+
 spec:
   parameters:
   - name: GCPProjectID
     type: Input
-    description: What is the GCP project ID?
+    prompt: What is the GCP project ID?
   - name: K8SMasterUser
     type: Input
-    description: What is the username for Kubernetes cluster?
+    prompt: What is the username for Kubernetes cluster?
     default: admin
   - name: K8SMasterPassword
-    type: Input
-    secret: true
-    description: What is the password for Kubernetes cluster? (minimum 16 characters)
-    pattern: "(\\S){16,}"
+    type: SecretInput
+    prompt: What is the password for Kubernetes cluster? (minimum 16 characters)
+    validate: !expr "regex('(\\\\S){16,}', K8SMasterPassword)"
   - name: ClusterName
     type: Input
-    description: What is the name of the cluster?
+    prompt: What is the name of the cluster?
   - name: GCPRegion
     type: Select
-    description: "Select the GCP region:"
+    prompt: "Select the GCP region:"
     options:
-    - asia-east1
-    - asia-east2
-    - asia-northeast1
-    - asia-south1
-    - asia-southeast1
-    - australia-southeast1
-    - europe-north1
-    - europe-west1
-    - europe-west2
-    - europe-west3
-    - europe-west4
-    - northamerica-northeast1
-    - southamerica-east1
-    - us-central1
-    - us-east1
-    - us-east4
-    - us-west1
-    - us-west2
+    - label: Taiwan
+      value: asia-east1
+    - label: Hong Kong
+      value: asia-east2
+    - label: Japan
+      value: asia-northeast1
+    - label: India
+      value: asia-south1
+    - label: Singapore
+      value: asia-southeast1
+    - label: Australia (Sydney)
+      value: australia-southeast1
+    - label: Finland
+      value: europe-north1
+    - label: Belgium
+      value: europe-west1
+    - label: England
+      value: europe-west2
+    - label: Germany
+      value: europe-west3
+    - label: Netherlands
+      value: europe-west4
+    - label: Canada
+      value: northamerica-northeast1
+    - label: Brazil
+      value: southamerica-east1
+    - label: Iowa, USA
+      value: us-central1
+    - label: South Carolina, USA
+      value: us-east1
+    - label: Northern Virginia, USA
+      value: us-east4
+    - label: Oregon, USA
+      value: us-west1
+    - label: California, USA
+      value: us-west2
   - name: GKENumNodes
     type: Input
+    prompt: What is the number of nodes in each GKE cluster zone?
     default: 2
-    description: What is the number of nodes in each GKE cluster zone?
   - name: GKENodeMachineType
     type: Select
-    description: What is the machine type of the GKE nodes?
+    prompt: What is the machine type of the GKE nodes?
     options:
-    - n1-standard-1
-    - n1-standard-2
-    - n1-standard-4
-    - n1-standard-8
-    - n1-standard-16
-    - n1-standard-32
-    - n1-standard-64
-    - n1-standard-96
-    - n1-highmem-2
-    - n1-highmem-4
-    - n1-highmem-8
-    - n1-highmem-16
-    - n1-highmem-32
-    - n1-highmem-64
-    - n1-highmem-96
-    - n1-highcpu-2
-    - n1-highcpu-4
-    - n1-highcpu-8
-    - n1-highcpu-16
-    - n1-highcpu-32
-    - n1-highcpu-64
-    - n1-highcpu-96
-    - f1-micro
-    - g1-small
-    - n1-ultramem-40
-    - n1-ultramem-80
-    - n1-ultramem-160
-    - n1-megamem-96
+      - n1-standard-1
+      - n1-standard-2
+      - n1-standard-4
+      - n1-standard-8
+      - n1-standard-16
+      - n1-standard-32
+      - n1-standard-64
+      - n1-standard-96
+      - n1-highmem-2
+      - n1-highmem-4
+      - n1-highmem-8
+      - n1-highmem-16
+      - n1-highmem-32
+      - n1-highmem-64
+      - n1-highmem-96
+      - n1-highcpu-2
+      - n1-highcpu-4
+      - n1-highcpu-8
+      - n1-highcpu-16
+      - n1-highcpu-32
+      - n1-highcpu-64
+      - n1-highcpu-96
+      - f1-micro
+      - g1-small
+      - n1-ultramem-40
+      - n1-ultramem-80
+      - n1-ultramem-160
+      - n1-megamem-96
 
   # Hidden prefix
   - name: Prefix
-    type: Input
     value: gcp-gke-
 
   files:
@@ -107,4 +124,3 @@ spec:
   - path: terraform-gcp-basic-gke-cluster/variables.tf
   # docker-compose setup for required tools
   - path: docker/docker-compose.yml
-

--- a/gcp/microservice-ecommerce/blueprint.yaml
+++ b/gcp/microservice-ecommerce/blueprint.yaml
@@ -1,85 +1,97 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  projectName: GCP-Microservice-GKE-with-JHipster
+  name: GCP-Microservice-GKE-with-JHipster
   description: |
     The blueprint deploys an e-commerce microservice application to GCP GKE.
     XL Deploy does the provisioning and deployment, while XL Release orchestrates everything.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
+
 spec:
   parameters:
   # General variables
   - name: AppName
     type: Input
-    description: What is the name of the application?
+    prompt: What is the name of the application?
   # GCP specific variables
   - name: GCPProjectID
     type: Input
-    description: What is the GCP project ID?
+    prompt: What is the GCP project ID?
   - name: K8SMasterUser
     type: Input
-    description: What is the username for Kubernetes cluster?
+    prompt: What is the username for Kubernetes cluster?
     default: admin
   - name: K8SMasterPassword
-    type: Input
-    secret: true
-    description: What is the password for Kubernetes cluster? (minimum 16 characters)
-    pattern: "(\\S){16,}"
+    type: SecretInput
+    prompt: What is the password for Kubernetes cluster? (minimum 16 characters)
+    validate: !expr "regex('(\\\\S){16,}', K8SMasterPassword)"
   - name: GCPRegion
     type: Select
-    description: "Select the GCP region:"
+    prompt: "Select the GCP region:"
     options:
-      - asia-east1
-      - asia-east2
-      - asia-northeast1
-      - asia-south1
-      - asia-southeast1
-      - australia-southeast1
-      - europe-north1
-      - europe-west1
-      - europe-west2
-      - europe-west3
-      - europe-west4
-      - northamerica-northeast1
-      - southamerica-east1
-      - us-central1
-      - us-east1
-      - us-east4
-      - us-west1
-      - us-west2
+      - label: Taiwan
+        value: asia-east1
+      - label: Hong Kong
+        value: asia-east2
+      - label: Japan
+        value: asia-northeast1
+      - label: India
+        value: asia-south1
+      - label: Singapore
+        value: asia-southeast1
+      - label: Australia (Sydney)
+        value: australia-southeast1
+      - label: Finland
+        value: europe-north1
+      - label: Belgium
+        value: europe-west1
+      - label: England
+        value: europe-west2
+      - label: Germany
+        value: europe-west3
+      - label: Netherlands
+        value: europe-west4
+      - label: Canada
+        value: northamerica-northeast1
+      - label: Brazil
+        value: southamerica-east1
+      - label: Iowa, USA
+        value: us-central1
+      - label: South Carolina, USA
+        value: us-east1
+      - label: Northern Virginia, USA
+        value: us-east4
+      - label: Oregon, USA
+        value: us-west1
+      - label: California, USA
+        value: us-west2
 
   - name: ProvisionCluster
     type: Confirm
-    description: Do you want to provision a new GCP GKE cluster?
+    prompt: Do you want to provision a new GCP GKE cluster?
   - name: ClusterName
     type: Input
-    description: What is the name of the cluster?
+    prompt: What is the name of the cluster?
   - name: ClusterEndpoint
     type: Input
-    dependsOnFalse: ProvisionCluster
-    description: What is the endpoint for the cluster, example https://104.155.109.230
+    prompt: What is the endpoint for the cluster, example https://104.155.109.230
+    promptIf: !expr "!ProvisionCluster"
   - name: Namespace
-    type: Input
-    description: What is the name of the namespace? This should be same as the one used in Kubernetes files.
     value: xl-demo
   - name: enableCICD
     type: Confirm
-    description: Do you want to enable CI/CD integration with Jenkins?
+    prompt: Do you want to enable CI/CD integration with Jenkins?
   - name: StoreAdminUsername
-    type: Input
-    description: Store Admin username
     value: admin
   - name: StoreAdminPassword
-    type: Input
-    description: Store Admin password
+    type: SecretInput
     value: admin
-    secret: true
   - name: XLDUrlForXLR
     type: Input
-    description: XL Deploy URL for XL Release (This will only be used in the XL Release template)
+    prompt: XL Deploy URL for XL Release (This will only be used in the XL Release template)
     default: http://xl-deploy:4516
 
   files:
@@ -92,29 +104,28 @@ spec:
   - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl
   - path: xebialabs/USAGE.md.tmpl
   - path: terraform/gke/main.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/gke/outputs.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/gke/variables.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/vpc/main.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/vpc/outputs.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/vpc/variables.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/.gitignore
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/backend.tf.tmpl
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/main.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/outputs.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: terraform/variables.tf
-    dependsOnTrue: ProvisionCluster
+    writeIf: ProvisionCluster
   - path: xebialabs.yaml
-  # docker-compose setup for required tools
   - path: docker/docker-compose.yml
   - path: docker/data/configure-xl-devops-platform.yaml
   - path: docker/jenkins/jenkins.yaml

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -194,7 +194,7 @@ if __name__ == '__main__':
 
             os.chdir(tempdir.name)
 
-            command = ['xl', 'blueprint', '-b', '../{}'.format(blueprint_dir), '-sa', '../{}'.format(answers_file)]
+            command = ['xl', 'blueprint', '-l', '../', '-b', '{}'.format(blueprint_dir), '-sa', '../{}'.format(answers_file)]
             print('Executing: {}'.format(' '.join(command)))
             result = subprocess.run(command, capture_output=True, env=env)
             if not result.returncode == 0:

--- a/kubernetes/application/blueprint.yaml
+++ b/kubernetes/application/blueprint.yaml
@@ -1,28 +1,30 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: Define a Kubernetes application
+  name: Define a Kubernetes application
   description: |
     This blueprint defines an application that can be deployed to Kubernetes
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Read xebialabs/USAGE-kubernetes-application.md to learn how to use this blueprint.
+
 spec:
   parameters:
   - name: KubernetesApplicationName
     type: Input
+    prompt: "What is the name of the application that you want to deploy?"
     default: nginx
-    description: "What is the name of the application that you want to deploy?"
 
   - name: KubernetesDeploymentPackageVersion
     type: Input
-    default: 'latest'
-    description: "What is the version of the application that you want to deploy?"
+    prompt: "What is the version of the application that you want to deploy?"
+    default: latest
 
   - name: KubernetesResourcesFile
     type: Input
+    prompt: "What is the path of the Kubernetes YAML file that you want to deploy?"
     default: '../kubernetes/nginx.yaml'
-    description: "What is the path of the Kubernetes YAML file that you want to deploy?"
 
   files:
   # XebiaLabs

--- a/kubernetes/environment/blueprint.yaml
+++ b/kubernetes/environment/blueprint.yaml
@@ -27,14 +27,12 @@ spec:
     value: !expr "k8sConfig('ClusterInsecureSkipTLSVerify')"
 
   - name: KubernetesClientCert
-    # TODO: Should be SecretEditor after feature is implemented
-    type: Editor
+    type: SecretEditor
     prompt: "Please enter the client certificate to use to connect to the Kubernetes cluster: "
     value: !expr "k8sConfig('UserClientCertificateData')"
 
   - name: KubernetesClientPrivateKey
-    # TODO: Should be SecretEditor after feature is implemented
-    type: Editor
+    type: SecretEditor
     prompt: "Please enter the client private key to use to connect to the Kubernetes cluster: "
     value: !expr "k8sConfig('UserClientKeyData')"
 

--- a/kubernetes/environment/blueprint.yaml
+++ b/kubernetes/environment/blueprint.yaml
@@ -1,48 +1,55 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
+
 metadata:
-  projectName: Create infrastructure and environment for Kubernetes
+  name: Create infrastructure and environment for Kubernetes
   description: |
     This blueprint defines an environment for a Kubernetes cluster based on the information in your ~/.kube/config file
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Read xebialabs/USAGE-kubernetes-environment.md to learn how to use this blueprint.
+
 spec:
   parameters:
   - name: KubernetesName
     type: Input
-    value: !fn k8s.config().ContextCluster
-    description: "What is the name of the Kubernetes cluster?"
+    prompt: "What is the name of the Kubernetes cluster?"
+    # TODO: Should be changed to value instead of default after limitation is removed
+    default: !expr "k8sConfig('ContextCluster')"
 
   - name: KubernetesURL
     type: Input
-    value: !fn k8s.config().ClusterServer
-    description: "What is the URL of the Kubernetes cluster?"
+    prompt: "What is the URL of the Kubernetes cluster?"
+    # TODO: Should be changed to value instead of default after limitation is removed
+    default: !expr "k8sConfig('ClusterServer')"
 
   - name: KubernetesSkipTLSVerify
     type: Confirm
-    value: !fn k8s.config().ClusterInsecureSkipTLSVerify
-    description: "Does the Kubernetes cluster have a self-signed certificate?"
+    prompt: "Does the Kubernetes cluster have a self-signed certificate?"
+    # TODO: Should be changed to value instead of default after limitation is removed
+    default: !expr "k8sConfig('ClusterInsecureSkipTLSVerify')"
 
   - name: KubernetesClientCert
+    # TODO: Should be SecretEditor after feature is implemented
     type: Editor
-    value: !fn k8s.config().UserClientCertificateData
-    secret: true
-    description: "Please enter the client certificate to use to connect to the Kubernetes cluster: "
+    prompt: "Please enter the client certificate to use to connect to the Kubernetes cluster: "
+    # TODO: Should be changed to value instead of default after limitation is removed
+    default: !expr "k8sConfig('UserClientCertificateData')"
 
   - name: KubernetesClientPrivateKey
+    # TODO: Should be SecretEditor after feature is implemented
     type: Editor
-    value: !fn k8s.config().UserClientKeyData
-    secret: true
-    description: "Please enter the client private key to use to connect to the Kubernetes cluster: "
+    prompt: "Please enter the client private key to use to connect to the Kubernetes cluster: "
+    # TODO: Should be changed to value instead of default after limitation is removed
+    default: !expr "k8sConfig('UserClientKeyData')"
 
   - name: KubernetesNamespace
     type: Input
-    value: !fn k8s.config().ContextNamespace
-    default: default
-    description: "Which namespace in the Kubernetes cluster should be used?"
+    prompt: "Which namespace in the Kubernetes cluster should be used?"
+    # TODO: Should be changed to value instead of default after limitation is removed
+    default: !expr "k8sConfig('ContextNamespace')"
+    #default: default
 
   files:
-  # XebiaLabs
-  - path: xebialabs/USAGE-kubernetes-environment.md
-  - path: xebialabs/kubernetes-environment.yaml.tmpl
+    - path: xebialabs/USAGE-kubernetes-environment.md
+    - path: xebialabs/kubernetes-environment.yaml.tmpl

--- a/kubernetes/environment/blueprint.yaml
+++ b/kubernetes/environment/blueprint.yaml
@@ -14,41 +14,35 @@ spec:
   - name: KubernetesName
     type: Input
     prompt: "What is the name of the Kubernetes cluster?"
-    # TODO: Should be changed to value instead of default after limitation is removed
-    default: !expr "k8sConfig('ContextCluster')"
+    value: !expr "k8sConfig('ContextCluster')"
 
   - name: KubernetesURL
     type: Input
     prompt: "What is the URL of the Kubernetes cluster?"
-    # TODO: Should be changed to value instead of default after limitation is removed
-    default: !expr "k8sConfig('ClusterServer')"
+    value: !expr "k8sConfig('ClusterServer')"
 
   - name: KubernetesSkipTLSVerify
     type: Confirm
     prompt: "Does the Kubernetes cluster have a self-signed certificate?"
-    # TODO: Should be changed to value instead of default after limitation is removed
-    default: !expr "k8sConfig('ClusterInsecureSkipTLSVerify')"
+    value: !expr "k8sConfig('ClusterInsecureSkipTLSVerify')"
 
   - name: KubernetesClientCert
     # TODO: Should be SecretEditor after feature is implemented
     type: Editor
     prompt: "Please enter the client certificate to use to connect to the Kubernetes cluster: "
-    # TODO: Should be changed to value instead of default after limitation is removed
-    default: !expr "k8sConfig('UserClientCertificateData')"
+    value: !expr "k8sConfig('UserClientCertificateData')"
 
   - name: KubernetesClientPrivateKey
     # TODO: Should be SecretEditor after feature is implemented
     type: Editor
     prompt: "Please enter the client private key to use to connect to the Kubernetes cluster: "
-    # TODO: Should be changed to value instead of default after limitation is removed
-    default: !expr "k8sConfig('UserClientKeyData')"
+    value: !expr "k8sConfig('UserClientKeyData')"
 
   - name: KubernetesNamespace
     type: Input
     prompt: "Which namespace in the Kubernetes cluster should be used?"
-    # TODO: Should be changed to value instead of default after limitation is removed
-    default: !expr "k8sConfig('ContextNamespace')"
-    #default: default
+    value: !expr "k8sConfig('ContextNamespace')"
+    default: default
 
   files:
     - path: xebialabs/USAGE-kubernetes-environment.md

--- a/xl-devops-platform/blueprint.yaml
+++ b/xl-devops-platform/blueprint.yaml
@@ -1,54 +1,54 @@
-apiVersion: xl/v1
+apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  projectName: Docker compose
+  name: Docker compose
   description: Creates the necessary `docker-compose.yaml` needed to run your specific setup.
   author: XebiaLabs
-  version: 1.0
+  version: 2.0
   instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
   
 spec:
   parameters:
   - name: UseXLDeployFlag
     type: Confirm
-    description: Do you want to install XL Deploy?
+    prompt: Do you want to install XL Deploy?
     default: true
 
   - name: XLDeployPort
     type: Input
-    description: "Host port for XL Deploy:"
+    prompt: "Host port for XL Deploy:"
+    promptIf: UseXLDeployFlag
     default: 4516
-    dependsOnTrue: UseXLDeployFlag
 
   - name: UseXLReleaseFlag
     type: Confirm
-    description: Do you want to install XL Release?
+    prompt: Do you want to install XL Release?
     default: true
 
   - name: XLReleasePort
     type: Input
-    description: "Host port for XL Release:"
+    prompt: "Host port for XL Release:"
+    promptIf: UseXLReleaseFlag
     default: 5516
-    dependsOnTrue: UseXLReleaseFlag
 
   - name: JetPackOrEnterprise
     type: Select
-    description: "Do you want to use JetPack or XL Enterprise:"
+    prompt: "Do you want to use JetPack or XL Enterprise:"
     options:
-    - JetPack
-    - XL Enterprise
+      - JetPack
+      - XL Enterprise
 
   - name: XLVersion
     type: Select
-    description: "Select the version of XL you want to use:"
+    prompt: "Select the version of XL you want to use:"
+    promptIf: !expr "UseXLDeployFlag == true || UseXLReleaseFlag == true"
     options:
-    - 8.6.1
-    dependsOnTrue: !expression "UseXLDeployFlag == true || UseXLReleaseFlag == true"
+      - 8.6.1
 
   - name: UseDockerProxyFlag
     type: Confirm
-    description: Do you want to be able to deploy to your local Docker instance?
+    prompt: Do you want to be able to deploy to your local Docker instance?
     default: true
 
   files:
@@ -56,4 +56,4 @@ spec:
   - path: xebialabs/config.yaml.tmpl
   - path: docker/docker-compose.yml.tmpl
   - path: docker/data/configure-xl-devops-platform.yaml.tmpl
-    dependsOnTrue: UseXLReleaseFlag
+    writeIf: UseXLReleaseFlag


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [x] The Travis CI for the PR is green
- [x] The blueprint has been reviewed by someone else in the team.
- [x] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [x] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [x] The blueprint works on Linux, Mac and Windows.
