### PR TITLE
LOVE-751 blueprint for Azure app service

### DIFF
--- a/azure/app-service-docker-app/README.md
+++ b/azure/app-service-docker-app/README.md
@@ -1,8 +1,8 @@
 ## Introduction
 
-Azure Kubernetes Service (AKS) allows you to deploy, manage, and scale containerized applications in the cloud using Kubernetes.
+Azure App Service allows you to deploy, manage, and scale web applications in the cloud.
 
-Use this blueprint to provision a simple AKS cluster using Terraform, which defines the infrastructure that will run on AKS.
+Use this blueprint to provision a simple Dockerized Web application using Terraform and XL Deploy, which defines the infrastructure that will run on Azure.
 
 ## Before you get started
 
@@ -17,7 +17,7 @@ If you're new to XebiaLabs blueprints, check out:
 To use this blueprint, run `xl blueprint` in an empty directory and select:
 
 ```plain
-azure/basic-aks-cluster
+azure/app-service-docker-app
 ```
 
 ## Tools and technologies
@@ -25,10 +25,9 @@ azure/basic-aks-cluster
 This blueprint includes the following tools and technologies:
 
 * Target:
-    * [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/services/kubernetes-service/)
+    * [Azure App Service](https://azure.microsoft.com/en-in/services/app-service/)
 * Tools:
     * [XebiaLabs Deployment Automation](https://xebialabs.com/products/xl-deploy/)
-    * [Kubernetes](https://kubernetes.io/)
     * [Terraform](https://www.terraform.io/)
 
 
@@ -36,8 +35,8 @@ This blueprint includes the following tools and technologies:
 
 This blueprint version requires at least the following versions of the specified tools to work properly:
 
-- XL Deploy: Version 8.6.1
-- XL CLI: Version 8.6.0
+- XL Deploy: Version 9.0.0
+- XL CLI: Version 9.0.0
 
 ## Prerequisites
 
@@ -100,18 +99,19 @@ In this output:
 
 > Note: You already retrieved your `subscription_id` in the previous step.
 
-
 ## Output
 
 This blueprint will output:
 
 * Terraform templates
 * Infrastructure:
-    * AKS cluster (master, nodes)
+    * AppService
+    * MySQL server
 
 ## Labels
 
 * Cloud
 * Microsoft
 * Azure
-* Kubernetes
+* AppService
+* Docker

--- a/azure/app-service-docker-app/__test__/answers-no-app.yaml
+++ b/azure/app-service-docker-app/__test__/answers-no-app.yaml
@@ -1,0 +1,9 @@
+AppName: MyApp
+SubscriptionID: C
+ClientID: A
+ClientSecret: B
+TenantID: D
+ResourceGroupLocation: westeurope
+UseSampleApplication: false
+DockerImage: test
+DockerImageTag: test

--- a/azure/app-service-docker-app/__test__/answers-with-app.yaml
+++ b/azure/app-service-docker-app/__test__/answers-with-app.yaml
@@ -1,0 +1,8 @@
+AppName: MyApp
+SubscriptionID: C
+ClientID: A
+ClientSecret: B
+TenantID: D
+ResourceGroupLocation: westeurope
+UseSampleApplication: true
+MySqlMasterPassword: Test@1234

--- a/azure/app-service-docker-app/__test__/test-no-app.yaml
+++ b/azure/app-service-docker-app/__test__/test-no-app.yaml
@@ -1,4 +1,4 @@
-answers-file: answers.yaml
+answers-file: answers-no-app.yaml
 expected-files:
 - xebialabs/azure-app-service.yaml
 - xebialabs/USAGE.md

--- a/azure/app-service-docker-app/__test__/test-no-app.yaml
+++ b/azure/app-service-docker-app/__test__/test-no-app.yaml
@@ -1,0 +1,8 @@
+answers-file: answers.yaml
+expected-files:
+- xebialabs/azure-app-service.yaml
+- xebialabs/USAGE.md
+- terraform/main.tf
+- terraform/outputs.tf
+- terraform/variables.tf
+- docker/docker-compose.yml

--- a/azure/app-service-docker-app/__test__/test-with-app.yaml
+++ b/azure/app-service-docker-app/__test__/test-with-app.yaml
@@ -1,0 +1,8 @@
+answers-file: answers.yaml
+expected-files:
+- xebialabs/azure-app-service.yaml
+- xebialabs/USAGE.md
+- terraform/main.tf
+- terraform/outputs.tf
+- terraform/variables.tf
+- docker/docker-compose.yml

--- a/azure/app-service-docker-app/__test__/test-with-app.yaml
+++ b/azure/app-service-docker-app/__test__/test-with-app.yaml
@@ -1,4 +1,4 @@
-answers-file: answers.yaml
+answers-file: answers-with-app.yaml
 expected-files:
 - xebialabs/azure-app-service.yaml
 - xebialabs/USAGE.md

--- a/azure/app-service-docker-app/blueprint.yaml
+++ b/azure/app-service-docker-app/blueprint.yaml
@@ -1,0 +1,145 @@
+apiVersion: xl/v2
+kind: Blueprint
+
+metadata:
+  name: Azure-App-Service
+  description: |
+    The blueprint provisions an Azure App service instance with given Docker image or with a sample application
+  author: XebiaLabs
+  version: 2.0
+  instructions: Please read the generated file "xebialabs/USAGE.md" for further usage instructions.
+
+spec:
+  parameters:
+
+  # ############################################################################
+  # Access and authorization
+  # ############################################################################
+  - name: SubscriptionID
+    type: Input
+    prompt: What is your existing Azure subscription id?
+
+  - name: ClientID
+    type: Input
+    prompt: What is the client id (appId) of an existing Service Principal in Azure?
+
+  - name: ClientSecret
+    type: SecretInput
+    prompt: What is the secret (password) for that client id?
+
+  - name: TenantID
+    type: Input
+    prompt: What is your existing Azure tenant id?
+
+  # ############################################################################
+  # Location and app details
+  # ############################################################################
+  - name: ResourceGroupLocation
+    type: Select
+    prompt: "Select where this resource group will go:"
+    options:
+      - label: East Asia
+        value: eastasia
+      - label: Southeast Asia
+        value: southeastasia
+      - label: Central US
+        value: centralus
+      - label: East US
+        value: eastus
+      - label: East US 2
+        value: eastus2
+      - label: West US
+        value: westus
+      - label: North Central US
+        value: northcentralus
+      - label: South Central US
+        value: southcentralus
+      - label: North Europe
+        value: northeurope
+      - label: West Europe
+        value: westeurope
+      - label: Japan West
+        value: japanwest
+      - label: Japan East
+        value: japaneast
+      - label: Brazil South
+        value: brazilsouth
+      - label: Australia East
+        value: australiaeast
+      - label: Australia Southeast
+        value: australiasoutheast
+      - label: South India
+        value: southindia
+      - label: Central India
+        value: centralindia
+      - label: West India
+        value: westindia
+      - label: Canada Central
+        value: canadacentral
+      - label: Canada East
+        value: canadaeast
+      - label: UK South
+        value: uksouth
+      - label: UK West
+        value: ukwest
+      - label: West Central US
+        value: westcentralus
+      - label: West US 2
+        value: westus2
+      - label: Korea Central
+        value: koreacentral
+      - label: Korea South
+        value: koreasouth
+      - label: France Central
+        value: francecentral
+      - label: France South
+        value: francesouth
+      - label: Australia Central
+        value: australiacentral
+      - label: Australia Central 2
+        value: australiacentral2
+      - label: South Africa North
+        value: southafricanorth
+      - label: South Africa West
+        value: southafricawest
+
+  - name: AppName
+    type: Input
+    prompt: What do you want to name the application?
+    validate: !expr "regex('[a-zA-Z0-9-]*', AppName)"
+
+  - name: UseSampleApplication
+    type: Confirm
+    prompt: Do you want to deploy a sample application?
+    default: true
+    description: Deploy the sample application from https://github.com/xebialabs/e-commerce-monolith
+
+  - name: MySqlMasterPassword
+    type: SecretInput
+    prompt: What is the master password to use for MySQL server that will be provisioned?
+    validate: !expr "regex('^(?=.*?[0-9])(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[-._!#^~@$%*]).{8,128}$', MySqlMasterPassword)"
+    promptIf: !expr "UseSampleApplication"
+
+  - name: DockerImage
+    type: Input
+    prompt: What is the docker image path that you would like to use?
+    default: xebialabsunsupported/ecommerce-monolith
+    value: !expr "UseSampleApplication ? 'xebialabsunsupported/ecommerce-monolith' : ''"
+
+  - name: DockerImageTag
+    type: Input
+    prompt: What is the docker image tag to be used?
+    default: latest
+    value: !expr "UseSampleApplication ? 'latest' : ''"
+
+  files:
+  # XebiaLabs
+  - path: xebialabs/USAGE.md.tmpl
+  - path: xebialabs/azure-app-service.yaml.tmpl
+  # Terraform
+  - path: terraform/.gitignore
+  - path: terraform/main.tf.tmpl
+  - path: terraform/outputs.tf
+  - path: terraform/variables.tf.tmpl
+  # Docker
+  - path: docker/docker-compose.yml

--- a/azure/app-service-docker-app/blueprint.yaml
+++ b/azure/app-service-docker-app/blueprint.yaml
@@ -106,7 +106,7 @@ spec:
   - name: AppName
     type: Input
     prompt: What do you want to name the application?
-    validate: !expr "regex('[a-zA-Z0-9-]*', AppName)"
+    validate: !expr "regex('^[a-zA-Z0-9-]*$', AppName)"
 
   - name: UseSampleApplication
     type: Confirm
@@ -116,9 +116,13 @@ spec:
 
   - name: MySqlMasterPassword
     type: SecretInput
-    prompt: What is the master password to use for MySQL server that will be provisioned?
+    prompt: What is the master password to use for MySQL server that will be provisioned? 
+    description: A complex password for MySQL server user. Needs minimum 8 character with at least 1 lowercase, 1 uppercase, 1 number and 1 special character 
     validate: !expr "regex('^(?=.*?[0-9])(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[-._!#^~@$%*]).{8,128}$', MySqlMasterPassword)"
     promptIf: !expr "UseSampleApplication"
+
+  - name: MySqlMasterUsername
+    value: mysqladminun
 
   - name: DockerImage
     type: Input

--- a/azure/app-service-docker-app/blueprint.yaml
+++ b/azure/app-service-docker-app/blueprint.yaml
@@ -110,9 +110,9 @@ spec:
 
   - name: UseSampleApplication
     type: Confirm
-    prompt: Do you want to deploy a sample application?
+    prompt: Do you want to deploy a sample application with its database?
     default: true
-    description: Deploy the sample application from https://github.com/xebialabs/e-commerce-monolith
+    description: Deploy the sample application from https://github.com/xebialabs/e-commerce-monolith with a MySQL server database
 
   - name: MySqlMasterPassword
     type: SecretInput

--- a/azure/app-service-docker-app/docker/docker-compose.yml
+++ b/azure/app-service-docker-app/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  xl-deploy:
+    image: xebialabs/xl-jetpack-deploy:8.6.1
+    ports:
+    - "4516:4516"
+    environment:
+    - ADMIN_PASSWORD=admin
+    - ACCEPT_EULA=Y

--- a/azure/app-service-docker-app/terraform/.gitignore
+++ b/azure/app-service-docker-app/terraform/.gitignore
@@ -1,0 +1,4 @@
+.terraform
+terraform.tfstate
+*.tfstate*
+*.tfvars

--- a/azure/app-service-docker-app/terraform/main.tf.tmpl
+++ b/azure/app-service-docker-app/terraform/main.tf.tmpl
@@ -31,8 +31,8 @@ resource "azurerm_mysql_server" "main" {
     geo_redundant_backup  = "Disabled"
   }
 
-  administrator_login          = "mysqladminun"
-  administrator_login_password = "${var.my_sql_master_password}"
+  administrator_login          = "${var.mysql_master_username}"
+  administrator_login_password = "${var.mysql_master_password}"
   version                      = "5.7"
   ssl_enforcement              = "Disabled"
 }
@@ -91,8 +91,8 @@ resource "azurerm_app_service" "main" {
     {{- if .UseSampleApplication }}
     "SPRING_PROFILES_ACTIVE"     = "prod,swagger"
     "SPRING_DATASOURCE_URL"      = "jdbc:mysql://${azurerm_mysql_server.main.fqdn}:3306/${azurerm_mysql_database.main.name}?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC"
-    "SPRING_DATASOURCE_USERNAME" = "${azurerm_mysql_server.main.administrator_login}@${azurerm_mysql_server.main.name}"
-    "SPRING_DATASOURCE_PASSWORD" = "${var.my_sql_master_password}"
+    "SPRING_DATASOURCE_USERNAME" = "${var.mysql_master_username}@${azurerm_mysql_server.main.name}"
+    "SPRING_DATASOURCE_PASSWORD" = "${var.mysql_master_password}"
     {{- end}}
   }
 }

--- a/azure/app-service-docker-app/terraform/main.tf.tmpl
+++ b/azure/app-service-docker-app/terraform/main.tf.tmpl
@@ -1,0 +1,98 @@
+provider "azurerm" {
+  version         = "=1.24.0"
+  subscription_id = "${var.subscription_id}"
+  client_id       = "${var.client_id}"
+  client_secret   = "${var.client_secret}"
+  tenant_id       = "${var.tenant_id}"
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+{{- if .UseSampleApplication }}
+# This creates a MySQL server
+resource "azurerm_mysql_server" "main" {
+  name                = "${var.prefix}-mysql-server"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+
+  sku {
+    name     = "B_Gen5_2"
+    capacity = 2
+    tier     = "Basic"
+    family   = "Gen5"
+  }
+
+  storage_profile {
+    storage_mb            = 5120
+    backup_retention_days = 7
+    geo_redundant_backup  = "Disabled"
+  }
+
+  administrator_login          = "mysqladminun"
+  administrator_login_password = "${var.my_sql_master_password}"
+  version                      = "5.7"
+  ssl_enforcement              = "Disabled"
+}
+
+# This is the database that our application will use
+resource "azurerm_mysql_database" "main" {
+  name                = "${var.db_name_prefix}_mysql_db"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  server_name         = "${azurerm_mysql_server.main.name}"
+  charset             = "utf8"
+  collation           = "utf8_unicode_ci"
+}
+
+# This rule is to enable the 'Allow access to Azure services' checkbox
+resource "azurerm_mysql_firewall_rule" "main" {
+  name                = "${var.prefix}-mysql-firewall"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  server_name         = "${azurerm_mysql_server.main.name}"
+  start_ip_address    = "0.0.0.0"
+  end_ip_address      = "0.0.0.0"
+}
+{{- end}}
+
+# This creates the plan that the service use
+resource "azurerm_app_service_plan" "main" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+# This creates the service definition
+resource "azurerm_app_service" "main" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.main.id}"
+
+  site_config {
+    app_command_line = ""
+    linux_fx_version = "DOCKER|${var.docker_image}:${var.docker_image_tag}"
+    always_on        = true
+  }
+
+  app_settings = {
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+    "DOCKER_REGISTRY_SERVER_URL"          = "https://index.docker.io"
+
+    # These are app specific environment variables go here
+    {{- if .UseSampleApplication }}
+    "SPRING_PROFILES_ACTIVE"     = "prod,swagger"
+    "SPRING_DATASOURCE_URL"      = "jdbc:mysql://${azurerm_mysql_server.main.fqdn}:3306/${azurerm_mysql_database.main.name}?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC"
+    "SPRING_DATASOURCE_USERNAME" = "${azurerm_mysql_server.main.administrator_login}@${azurerm_mysql_server.main.name}"
+    "SPRING_DATASOURCE_PASSWORD" = "${var.my_sql_master_password}"
+    {{- end}}
+  }
+}

--- a/azure/app-service-docker-app/terraform/outputs.tf
+++ b/azure/app-service-docker-app/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_name" {
+  value = "${azurerm_app_service.main.name}"
+}
+
+output "app_service_default_hostname" {
+  value = "https://${azurerm_app_service.main.default_site_hostname}"
+}

--- a/azure/app-service-docker-app/terraform/variables.tf.tmpl
+++ b/azure/app-service-docker-app/terraform/variables.tf.tmpl
@@ -32,8 +32,13 @@ variable "docker_image_tag" {
 }
 
 {{- if .UseSampleApplication }}
-variable "my_sql_master_password" {
+variable "mysql_master_password" {
   description = "MySql master password"
+}
+
+variable "mysql_master_username" {
+  description = "MySql master username"
+  default="mysqladminun"
 }
 
 variable "db_name_prefix" {

--- a/azure/app-service-docker-app/terraform/variables.tf.tmpl
+++ b/azure/app-service-docker-app/terraform/variables.tf.tmpl
@@ -1,0 +1,42 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+  default     = "xl"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}
+
+variable "subscription_id" {
+  description = "Azure Subscription ID to be used for billing"
+}
+
+variable "client_id" {
+  description = "Service Principal Client ID"
+}
+
+variable "client_secret" {
+  description = "Service Principal Client secret"
+}
+
+variable "tenant_id" {
+  description = "Service Principal Tenant ID"
+}
+
+variable "docker_image" {
+  description = "Docker image name"
+}
+
+variable "docker_image_tag" {
+  description = "Docker image tag"
+}
+
+{{- if .UseSampleApplication }}
+variable "my_sql_master_password" {
+  description = "MySql master password"
+}
+
+variable "db_name_prefix" {
+  description = "MySql DB name prefix"
+}
+{{- end}}

--- a/azure/app-service-docker-app/xebialabs/USAGE.md.tmpl
+++ b/azure/app-service-docker-app/xebialabs/USAGE.md.tmpl
@@ -1,4 +1,4 @@
-{{$appName := .AppName}}
+{{$appName := .AppName | kebabcase}}
 
 ## Provision web application on Azure App Service
 

--- a/azure/app-service-docker-app/xebialabs/USAGE.md.tmpl
+++ b/azure/app-service-docker-app/xebialabs/USAGE.md.tmpl
@@ -1,0 +1,28 @@
+{{$appName := .AppName}}
+
+## Provision web application on Azure App Service
+
+### Prerequisites
+
+To deploy this blueprint, follow the steps below:
+
+1. Apply the generated YAML configurations using the XL CLI. Open up a terminal in the folder where you generated the configuration. Then run:
+
+```plain
+xl apply -f xebialabs/azure-app-service.yaml
+```
+
+2. Go to XL Deploy, look for the `{{$appName}}-app` under `Applications`. Select the `1.0.0` item underneath, click on the ellipsis and select 'Deploy'. Select the `{{$appName}}-terraform` environment (there should be only one), press 'Deploy'.
+
+3. After the deployment process is complete, an App Service application will have been provisioned on Azure.
+
+4. In order to access the application you can check the entry `app_service_default_hostname` in dictionary `{{$appName}}-terraform-dictionary` created in XL Deploy under `Environment` after the deployment.
+
+5. To deprovision the service, go to the `{{$appName}}-terraform` environment under `Environment`, select the `{{$appName}}-app` item, press the ellipsis and select 'Undeploy'. Follow the instructions on screen.
+
+## Minimum required versions
+
+This blueprint version requires at least the following versions of the specified tools to work properly:
+
+- XL Deploy: Version 9.0.0
+- XL CLI: Version 9.0.0

--- a/azure/app-service-docker-app/xebialabs/azure-app-service.yaml.tmpl
+++ b/azure/app-service-docker-app/xebialabs/azure-app-service.yaml.tmpl
@@ -1,42 +1,42 @@
-
+{{$appName := .AppName | kebabcase}}
 apiVersion: xl-deploy/v1
 kind: Infrastructure
 spec:
-- name: {{ .AppName }}-terraform-host
+- name: {{ $appName }}-terraform-host
   type: overthere.LocalHost
   os: UNIX
   children:
   - name: terraform-client
     type: terraform.TerraformClient
     path: '/usr/local/bin'
-    workingDirectory: '/tmp/{{ .AppName }}-terraform'
+    workingDirectory: '/tmp/{{ $appName }}-terraform'
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Environments
 spec:
-- name: {{ .AppName }}-terraform
+- name: {{ $appName }}-terraform
   type: udm.Environment
   members:
-  - ~Infrastructure/{{ .AppName }}-terraform-host/terraform-client
+  - ~Infrastructure/{{ $appName }}-terraform-host/terraform-client
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Applications
 spec:
-- name: {{ .AppName }}-app
+- name: {{ $appName }}-app
   type: udm.Application
   children:
   - name: '1.0.0'
     type: udm.DeploymentPackage
     deployables:
-    - name: {{ .AppName }}-app-service
+    - name: {{ $appName }}-app-service
       type: terraform.Module
       file: !file ../terraform
       inputVariables:
-        prefix: {{.AppName}}
+        prefix: {{$appName}}
         location: {{.ResourceGroupLocation}}
         subscription_id: {{.SubscriptionID}}
         client_id: {{.ClientID}}
@@ -45,6 +45,7 @@ spec:
         docker_image: {{.DockerImage}}
         docker_image_tag: {{.DockerImageTag}}
         {{- if .UseSampleApplication }}
-        my_sql_master_password: {{.MySqlMasterPassword}}
+        mysql_master_password: {{.MySqlMasterPassword}}
+        mysql_master_username: {{.MySqlMasterUsername}}
         db_name_prefix: {{.AppName | snakecase}}
         {{- end}}

--- a/azure/app-service-docker-app/xebialabs/azure-app-service.yaml.tmpl
+++ b/azure/app-service-docker-app/xebialabs/azure-app-service.yaml.tmpl
@@ -1,0 +1,50 @@
+
+apiVersion: xl-deploy/v1
+kind: Infrastructure
+spec:
+- name: {{ .AppName }}-terraform-host
+  type: overthere.LocalHost
+  os: UNIX
+  children:
+  - name: terraform-client
+    type: terraform.TerraformClient
+    path: '/usr/local/bin'
+    workingDirectory: '/tmp/{{ .AppName }}-terraform'
+
+---
+
+apiVersion: xl-deploy/v1
+kind: Environments
+spec:
+- name: {{ .AppName }}-terraform
+  type: udm.Environment
+  members:
+  - ~Infrastructure/{{ .AppName }}-terraform-host/terraform-client
+
+---
+
+apiVersion: xl-deploy/v1
+kind: Applications
+spec:
+- name: {{ .AppName }}-app
+  type: udm.Application
+  children:
+  - name: '1.0.0'
+    type: udm.DeploymentPackage
+    deployables:
+    - name: {{ .AppName }}-app-service
+      type: terraform.Module
+      file: !file ../terraform
+      inputVariables:
+        prefix: {{.AppName}}
+        location: {{.ResourceGroupLocation}}
+        subscription_id: {{.SubscriptionID}}
+        client_id: {{.ClientID}}
+        client_secret: {{.ClientSecret}}
+        tenant_id: {{.TenantID}}
+        docker_image: {{.DockerImage}}
+        docker_image_tag: {{.DockerImageTag}}
+        {{- if .UseSampleApplication }}
+        my_sql_master_password: {{.MySqlMasterPassword}}
+        db_name_prefix: {{.AppName | snakecase}}
+        {{- end}}


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [x] The Travis CI for the PR is green
- [x] The blueprint has been reviewed by someone else in the team.
- [x] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [x] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [x] The blueprint works on Linux, Mac and Windows.
