### PR TITLE
LOVE-601 use auto created infra/env/dict

### DIFF
--- a/aws/basic-eks-cluster/xebialabs/xld-cloudformation-apps.yaml.tmpl
+++ b/aws/basic-eks-cluster/xebialabs/xld-cloudformation-apps.yaml.tmpl
@@ -104,52 +104,6 @@ spec:
             NodeInstanceType: {{.NodeInstanceType}}
             NodeAutoScalingGroupMinSize: {{.NodeAutoScalingGroupDesiredSize}}
             NodeAutoScalingGroupMaxSize: {{add .NodeAutoScalingGroupDesiredSize 1}}
-          boundTemplates:
-            - "../eks-cluster"
-            - "../aws-eks-{{$app}}"
-            - "../aws-eks-{{$app}}-kube-system"
-            - "../aws-eks-{{$app}}-dictionary"
-        # create infrastructure entry in XLD using the cluster info that was created
-        templates:
-        - name: eks-cluster
-          type: "template.k8s.Master"
-          apiServerURL: '{{"{{%outputVariables.ClusterEndpoint%}}"}}'
-          skipTLS: "true"
-          isEKS: "true"
-          clusterName: "{{$app}}-master"
-          accessKey: {{.AWSAccessKey}}
-          accessSecret: {{.AWSAccessSecret}}
-          instanceName: "{{$app}}/eks-cluster"
-          childTemplates:
-          # this namespace is needed for authentication to the cluster
-          - name: kube-system
-            type: "template.k8s.Namespace"
-            namespaceName: "kube-system"
-          - name: default
-            type: template.k8s.Namespace
-            namespaceName: "default"
-        # this dictionary is needed for aws-eks-{{$app}}-kube-system environment
-        - name: aws-eks-{{$app}}-dictionary
-          type: "template.udm.Dictionary"
-          instanceName: "{{$app}}/aws-eks-{{$app}}-dictionary"
-          entries:
-            NodeInstanceRole: '{{"{{%outputVariables.NodeInstanceRole%}}"}}'
-            EksUser: '{{"{{%outputVariables.EksUser%}}"}}'
-            EksUserArn: '{{"{{%outputVariables.EksUserArn%}}"}}'
-        # create environment entry in XLD for the newly created clusters
-        - name: aws-eks-{{$app}}
-          type: "template.udm.Environment"
-          instanceName: "{{$app}}/aws-eks-{{$app}}"
-          members:
-            - "../eks-cluster"
-            - "../eks-cluster/default"
-        - name: aws-eks-{{$app}}-kube-system
-          type: "template.udm.Environment"
-          instanceName: "{{$app}}/aws-eks-{{$app}}-kube-system"
-          members:
-            - "../eks-cluster/kube-system"
-          dictionaries:
-            - "../aws-eks-{{$app}}-dictionary"
 
     {{- if .ProvisionEFS }}
     - name: {{$app}}-cloudformation-efs

--- a/aws/basic-eks-cluster/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/aws/basic-eks-cluster/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -77,11 +77,17 @@ spec:
           server: XL Deploy
           deploymentPackage: {{$app}}/EKS-CLOUDFORMATION/{{$app}}-cloudformation-eks-workers/1.0.0
           deploymentEnvironment: Environments/{{$app}}/aws-cloudformation-{{$app}}
+        - name: Update workers dictionary for kube-system environment
+          type: xld.UpdateCIProperty
+          server: XL Deploy
+          ciID: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system
+          ciProperty: dictionaries
+          propertyValue: '[ "Environments/{{$app}}/{{$app}}-eks-workers-dictionary" ]'
         - name: Provision EKS config map for workers
           type: xldeploy.Deploy
           server: XL Deploy
           deploymentPackage: {{$app}}/EKS-CLOUDFORMATION/{{$app}}-k8s-configmap/1.0.0
-          deploymentEnvironment: Environments/{{$app}}/aws-eks-{{$app}}-kube-system
+          deploymentEnvironment: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system
 
       {{- if .ProvisionEFS }}
       - name: Provision AWS EFS

--- a/aws/basic-eks-cluster/xebialabs/xlr-pipeline-destroy.yaml.tmpl
+++ b/aws/basic-eks-cluster/xebialabs/xlr-pipeline-destroy.yaml.tmpl
@@ -37,6 +37,12 @@ spec:
           type: xldeploy.Undeploy
           server: XL Deploy
           deployedApplication: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system/{{$app}}-k8s-configmap
+        - name: Update workers dictionary for kube-system environment
+          type: xld.UpdateCIProperty
+          server: XL Deploy
+          ciID: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system
+          ciProperty: dictionaries
+          propertyValue: '[]'
         - name: Deprovision EKS workers nodes
           type: xldeploy.Undeploy
           server: XL Deploy

--- a/aws/basic-eks-cluster/xebialabs/xlr-pipeline-destroy.yaml.tmpl
+++ b/aws/basic-eks-cluster/xebialabs/xlr-pipeline-destroy.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
         - name: Deprovision EKS config map for workers
           type: xldeploy.Undeploy
           server: XL Deploy
-          deployedApplication: Environments/{{$app}}/aws-eks-{{$app}}-kube-system/{{$app}}-k8s-configmap
+          deployedApplication: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system/{{$app}}-k8s-configmap
         - name: Deprovision EKS workers nodes
           type: xldeploy.Undeploy
           server: XL Deploy

--- a/aws/datalake/xebialabs/xld-infrastructure.yaml.tmpl
+++ b/aws/datalake/xebialabs/xld-infrastructure.yaml.tmpl
@@ -60,12 +60,3 @@ spec:
           AdministratorName: {{.AdministratorName}}
           AdministratorEmail: {{.AdministratorEmail}}
           CognitoDomain: {{.CognitoDomain}}
-        boundTemplates:
-          - "../data-lake-dictionary"
-      templates:
-      - name: data-lake-dictionary
-        type: template.udm.Dictionary
-        instanceName: DATA-LAKE/data-lake-dictionary
-        entries:
-          DATALAKE_CONSOLE_URL: '{{"{{%outputVariables.ConsoleUrl%}}"}}'
-          COGNITO_USER_POOL_ID: '{{"{{%outputVariables.UserPoolId%}}"}}'

--- a/aws/datalake/xebialabs/xlr-pipeline.yaml.tmpl
+++ b/aws/datalake/xebialabs/xlr-pipeline.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
         - name: Get console URL
           type: xld.GetCIMapPropertyKey
           server: XL Deploy
-          ciID: Environments/DATA-LAKE/data-lake-dictionary
+          ciID: Environments/DATA-LAKE/provision-data-lake-stack-dictionary
           ciPropertyName: entries
           ciPropertyNameKey: DATALAKE_CONSOLE_URL
           variableMapping:
@@ -65,7 +65,7 @@ spec:
         - name: Get cognito user pool ID
           type: xld.GetCIMapPropertyKey
           server: XL Deploy
-          ciID: Environments/DATA-LAKE/data-lake-dictionary
+          ciID: Environments/DATA-LAKE/provision-data-lake-stack-dictionary
           ciPropertyName: entries
           ciPropertyNameKey: COGNITO_USER_POOL_ID
           variableMapping:

--- a/aws/microservice-ecommerce/xebialabs/xld-cloudformation-apps.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xld-cloudformation-apps.yaml.tmpl
@@ -95,6 +95,7 @@ spec:
           capabilities:
           - CAPABILITY_IAM
           - CAPABILITY_NAMED_IAM
+          environmentPath: aws-eks-{{$app}}
           inputVariables:
             ProjectName: {{$app}}
             VPCStackName: {{$app}}-eks-vpc
@@ -102,48 +103,8 @@ spec:
             ClusterStackName: {{$app}}-eks-master
             ClusterName: {{$app}}-master
             NodeGroupName: {{$app}}
-          boundTemplates:
-            - "../eks-cluster"
-            - "../aws-eks-{{$app}}"
-            - "../aws-eks-{{$app}}-kube-system"
-            - "../aws-eks-{{$app}}-dictionary"
-        # create infrastructure entry in XLD using the cluster info that was created
-        templates:
-        - name: eks-cluster
-          type: "template.k8s.Master"
-          apiServerURL: '{{"{{%outputVariables.ClusterEndpoint%}}"}}'
-          skipTLS: "true"
-          isEKS: "true"
-          clusterName: "{{$app}}-master"
-          accessKey: {{.AWSAccessKey}}
-          accessSecret: {{.AWSAccessSecret}}
-          instanceName: "{{$app}}/eks-cluster"
-          childTemplates:
-          # this namespace is needed for authentication to the cluster
-          - name: kube-system
-            type: "template.k8s.Namespace"
-            namespaceName: "kube-system"
-        # this dictionary is needed for aws-eks-{{$app}}-kube-system environment
-        - name: aws-eks-{{$app}}-dictionary
-          type: "template.udm.Dictionary"
-          instanceName: "{{$app}}/aws-eks-{{$app}}-dictionary"
-          entries:
-            NodeInstanceRole: '{{"{{%outputVariables.NodeInstanceRole%}}"}}'
-            EksUser: '{{"{{%outputVariables.EksUser%}}"}}'
-            EksUserArn: '{{"{{%outputVariables.EksUserArn%}}"}}'
-        # create environment entry in XLD for the newly created clusters
-        - name: aws-eks-{{$app}}
-          type: "template.udm.Environment"
-          instanceName: "{{$app}}/aws-eks-{{$app}}"
-          members:
-            - "../eks-cluster"
-        - name: aws-eks-{{$app}}-kube-system
-          type: "template.udm.Environment"
-          instanceName: "{{$app}}/aws-eks-{{$app}}-kube-system"
-          members:
-            - "../eks-cluster/kube-system"
-          dictionaries:
-            - "../aws-eks-{{$app}}-dictionary"
+        
+            
     # config map used to create custom user for authentication to the EKS cluster
     - name: {{$app}}-k8s-configmap
       type: udm.Application

--- a/aws/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -103,11 +103,17 @@ spec:
           server: XL Deploy
           deploymentPackage: {{$app}}/EKS-CLOUDFORMATION/{{$app}}-cloudformation-eks-workers/1.0.0
           deploymentEnvironment: Environments/{{$app}}/aws-cloudformation-{{$app}}
+        - name: Update workers dictionary for kube-system environment
+          type: xld.UpdateCIProperty
+          server: XL Deploy
+          ciID: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system
+          ciProperty: dictionaries
+          propertyValue: '[ "Environments/{{$app}}/{{$app}}-eks-workers-dictionary" ]'
         - name: Provision EKS config map for workers
           type: xldeploy.Deploy
           server: XL Deploy
           deploymentPackage: {{$app}}/EKS-CLOUDFORMATION/{{$app}}-k8s-configmap/1.0.0
-          deploymentEnvironment: Environments/{{$app}}/aws-eks-{{$app}}-kube-system
+          deploymentEnvironment: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system
     {{end}}
     - name: Build {{$app}} application
       type: xlrelease.Phase

--- a/aws/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
@@ -72,7 +72,13 @@ spec:
         - name: Deprovision EKS config map for workers
           type: xldeploy.Undeploy
           server: XL Deploy
-          deployedApplication: Environments/{{$app}}/aws-eks-{{$app}}-kube-system/{{$app}}-k8s-configmap
+          deployedApplication: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system/{{$app}}-k8s-configmap
+        - name: Update workers dictionary for kube-system environment
+          type: xld.UpdateCIProperty
+          server: XL Deploy
+          ciID: Environments/{{$app}}/{{$app}}-master-EKSCluster-kube-system
+          ciProperty: dictionaries
+          propertyValue: '[]'
         - name: Deprovision EKS workers nodes
           type: xldeploy.Undeploy
           server: XL Deploy

--- a/azure/app-service-docker-app/terraform/main.tf.tmpl
+++ b/azure/app-service-docker-app/terraform/main.tf.tmpl
@@ -93,6 +93,8 @@ resource "azurerm_app_service" "main" {
     "SPRING_DATASOURCE_URL"      = "jdbc:mysql://${azurerm_mysql_server.main.fqdn}:3306/${azurerm_mysql_database.main.name}?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC"
     "SPRING_DATASOURCE_USERNAME" = "${var.mysql_master_username}@${azurerm_mysql_server.main.name}"
     "SPRING_DATASOURCE_PASSWORD" = "${var.mysql_master_password}"
+    {{- else}}
+    "SPRING_PROFILES_ACTIVE"     = "dev"
     {{- end}}
   }
 }

--- a/azure/app-service-docker-app/xebialabs/USAGE.md.tmpl
+++ b/azure/app-service-docker-app/xebialabs/USAGE.md.tmpl
@@ -12,13 +12,13 @@ To deploy this blueprint, follow the steps below:
 xl apply -f xebialabs/azure-app-service.yaml
 ```
 
-2. Go to XL Deploy, look for the `{{$appName}}-app` under `Applications`. Select the `1.0.0` item underneath, click on the ellipsis and select 'Deploy'. Select the `{{$appName}}-terraform` environment (there should be only one), press 'Deploy'.
+2. Go to XL Deploy, look for the `{{$appName}}-app` under `Applications/{{ $appName }}`. Select the `1.0.0` item underneath, click on the ellipsis and select 'Deploy'. Select the `{{$appName}}-terraform` environment (there should be only one), press 'Deploy'.
 
 3. After the deployment process is complete, an App Service application will have been provisioned on Azure.
 
-4. In order to access the application you can check the entry `app_service_default_hostname` in dictionary `{{$appName}}-terraform-dictionary` created in XL Deploy under `Environment` after the deployment.
+4. In order to access the application you can check the entry `app_service_default_hostname` in dictionary `{{$appName}}-terraform-dictionary` created in XL Deploy under `Environment/{{ $appName }}` after the deployment.
 
-5. To deprovision the service, go to the `{{$appName}}-terraform` environment under `Environment`, select the `{{$appName}}-app` item, press the ellipsis and select 'Undeploy'. Follow the instructions on screen.
+5. To deprovision the service, go to the `{{$appName}}-terraform` environment under `Environment/{{ $appName }}`, select the `{{$appName}}-app` item, press the ellipsis and select 'Undeploy'. Follow the instructions on screen.
 
 ## Minimum required versions
 

--- a/azure/app-service-docker-app/xebialabs/azure-app-service.yaml.tmpl
+++ b/azure/app-service-docker-app/xebialabs/azure-app-service.yaml.tmpl
@@ -2,50 +2,59 @@
 apiVersion: xl-deploy/v1
 kind: Infrastructure
 spec:
-- name: {{ $appName }}-terraform-host
-  type: overthere.LocalHost
-  os: UNIX
+- name: {{ $appName }}
+  type: core.Directory
   children:
-  - name: terraform-client
-    type: terraform.TerraformClient
-    path: '/usr/local/bin'
-    workingDirectory: '/tmp/{{ $appName }}-terraform'
+  - name: {{ $appName }}-terraform-host
+    type: overthere.LocalHost
+    os: UNIX
+    children:
+    - name: terraform-client
+      type: terraform.TerraformClient
+      path: '/usr/local/bin'
+      workingDirectory: '/tmp/{{ $appName }}-terraform'
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Environments
 spec:
-- name: {{ $appName }}-terraform
-  type: udm.Environment
-  members:
-  - ~Infrastructure/{{ $appName }}-terraform-host/terraform-client
+- name: {{ $appName }}
+  type: core.Directory
+  children:
+  - name: {{ $appName }}-terraform
+    type: udm.Environment
+    members:
+    - ~Infrastructure/{{ $appName }}/{{ $appName }}-terraform-host/terraform-client
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Applications
 spec:
-- name: {{ $appName }}-app
-  type: udm.Application
+- name: {{ $appName }}
+  type: core.Directory
   children:
-  - name: '1.0.0'
-    type: udm.DeploymentPackage
-    deployables:
-    - name: {{ $appName }}-app-service
-      type: terraform.Module
-      file: !file ../terraform
-      inputVariables:
-        prefix: {{$appName}}
-        location: {{.ResourceGroupLocation}}
-        subscription_id: {{.SubscriptionID}}
-        client_id: {{.ClientID}}
-        client_secret: {{.ClientSecret}}
-        tenant_id: {{.TenantID}}
-        docker_image: {{.DockerImage}}
-        docker_image_tag: {{.DockerImageTag}}
-        {{- if .UseSampleApplication }}
-        mysql_master_password: {{.MySqlMasterPassword}}
-        mysql_master_username: {{.MySqlMasterUsername}}
-        db_name_prefix: {{.AppName | snakecase}}
-        {{- end}}
+  - name: {{ $appName }}-app
+    type: udm.Application
+    children:
+    - name: '1.0.0'
+      type: udm.DeploymentPackage
+      deployables:
+      - name: {{ $appName }}-app-service
+        type: terraform.Module
+        file: !file ../terraform
+        inputVariables:
+          prefix: {{$appName}}
+          location: {{.ResourceGroupLocation}}
+          subscription_id: {{.SubscriptionID}}
+          client_id: {{.ClientID}}
+          client_secret: {{.ClientSecret}}
+          tenant_id: {{.TenantID}}
+          docker_image: {{.DockerImage}}
+          docker_image_tag: {{.DockerImageTag}}
+          {{- if .UseSampleApplication }}
+          mysql_master_password: {{.MySqlMasterPassword}}
+          mysql_master_username: {{.MySqlMasterUsername}}
+          db_name_prefix: {{.AppName | snakecase}}
+          {{- end}}

--- a/azure/basic-aks-cluster/blueprint.yaml
+++ b/azure/basic-aks-cluster/blueprint.yaml
@@ -14,6 +14,10 @@ spec:
   # ############################################################################
   # Access and authorization
   # ############################################################################
+  - name: SubscriptionID
+    type: Input
+    prompt: What is your existing Azure subscription id?
+
   - name: ClientID
     type: Input
     prompt: What is the client id (appId) of an existing Service Principal in Azure?
@@ -21,10 +25,6 @@ spec:
   - name: ClientSecret
     type: SecretInput
     prompt: What is the secret (password) for that client id?
-
-  - name: SubscriptionID
-    type: Input
-    prompt: What is your existing Azure subscription id?
 
   - name: TenantID
     type: Input

--- a/azure/basic-aks-cluster/xebialabs/USAGE-azure-basic-aks-cluster.md.tmpl
+++ b/azure/basic-aks-cluster/xebialabs/USAGE-azure-basic-aks-cluster.md.tmpl
@@ -18,13 +18,13 @@ To deploy this blueprint, follow the steps below:
 xl apply -f xebialabs/azure-basic-aks-cluster.yaml
 ```
 
-2. Go to XL Deploy, look for the `basic-aks-cluster-terraform-for-{{$clusterName}}` folder under `Applications`. Select the `1.0.0` item underneath, click on the ellipsis and select 'Deploy'. Select the `terraform` environment (there should be only one), press 'Deploy'.
+2. Go to XL Deploy, look for the `basic-aks-cluster-terraform-for-{{$clusterName}}` folder under `Applications/{{ $clusterName }}`. Select the `1.0.0` item underneath, click on the ellipsis and select 'Deploy'. Select the `{{ .Prefix }}terraform` environment (there should be only one), press 'Deploy'.
 
 3. After the deployment process is complete, an AKS cluster will have been provisioned on Azure and a configured `K8s.master` environment will have been registered in XL Deploy.
 
 4. In order to deploy to the k8s cluster, you can execute any k8s blueprints to generate configurations, apply those and deploy the application to your new cluster using XL Deploy.
 
-5. To deprovision the AKS cluster, go to the terraform environment under `Environment`, select the `basic-aks-cluster-terraform-for-{{$clusterName}}` item, press the ellipsis and select 'Undeploy'. Follow the instructions on screen.
+5. To deprovision the AKS cluster, go to the terraform environment under `Environment/{{ $clusterName }}/{{ .Prefix }}-terraform`, select the `{{ .Prefix }}{{$clusterName}}` item, press the ellipsis and select 'Undeploy'. Follow the instructions on screen.
 
 ## Minimum required versions
 

--- a/azure/basic-aks-cluster/xebialabs/azure-basic-aks-cluster.yaml.tmpl
+++ b/azure/basic-aks-cluster/xebialabs/azure-basic-aks-cluster.yaml.tmpl
@@ -44,22 +44,4 @@ spec:
         tenant_id: {{.TenantID}}
         resource_group: {{.ResourceGroup}}
         resource_group_location: {{.ResourceGroupLocation}}
-      boundTemplates:
-      - "../{{$clusterName}} infrastructure"
-      - "../{{$clusterName}} environment"
-    templates:
-    - name: "{{$clusterName}} infrastructure"
-      type: template.k8s.Master
-      instanceName: {{$clusterName}}
-      apiServerURL: '{{"{{%outputVariables.host%}}"}}'
-      token: '{{"{{%outputVariables.token%}}"}}'
-      skipTLS: true
-      children:
-      - name: default
-        type: template.k8s.Namespace
-    - name: "{{$clusterName}} environment"
-      type: template.udm.Environment
-      instanceName: {{$clusterName}}
-      members:
-      - "../{{$clusterName}} infrastructure"
-      - "../{{$clusterName}} infrastructure/default"
+      environmentPath: "{{$clusterName}} environment"

--- a/azure/basic-aks-cluster/xebialabs/azure-basic-aks-cluster.yaml.tmpl
+++ b/azure/basic-aks-cluster/xebialabs/azure-basic-aks-cluster.yaml.tmpl
@@ -3,45 +3,54 @@
 apiVersion: xl-deploy/v1
 kind: Infrastructure
 spec:
-- name: {{ .Prefix }}terraform-host
-  type: overthere.LocalHost
-  os: UNIX
+- name: {{ $clusterName }}
+  type: core.Directory
   children:
-  - name: terraform-client
-    type: terraform.TerraformClient
-    path: '/usr/local/bin'
-    workingDirectory: '/tmp/{{ .Prefix }}terraform'
+  - name: {{ .Prefix }}terraform-host
+    type: overthere.LocalHost
+    os: UNIX
+    children:
+    - name: terraform-client
+      type: terraform.TerraformClient
+      path: '/usr/local/bin'
+      workingDirectory: '/tmp/{{ .Prefix }}terraform'
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Environments
 spec:
-- name: {{ .Prefix }}terraform
-  type: udm.Environment
-  members:
-  - ~Infrastructure/{{ .Prefix }}terraform-host/terraform-client
+- name: {{ $clusterName }}
+  type: core.Directory
+  children:
+  - name: {{ .Prefix }}terraform
+    type: udm.Environment
+    members:
+    - ~Infrastructure/{{ $clusterName }}/{{ .Prefix }}terraform-host/terraform-client
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Applications
 spec:
-- name: {{ .Prefix }}{{$clusterName}}
-  type: udm.Application
+- name: {{ $clusterName }}
+  type: core.Directory
   children:
-  - name: '1.0.0'
-    type: udm.DeploymentPackage
-    deployables:
-    - name: {{ .Prefix }}{{$clusterName}}
-      type: terraform.Module
-      file: !file ../terraform-azure-basic-aks-cluster
-      inputVariables:
-        cluster_name: {{$clusterName}}
-        subscription_id: {{.SubscriptionID}}
-        client_id: {{.ClientID}}
-        client_secret: {{.ClientSecret}}
-        tenant_id: {{.TenantID}}
-        resource_group: {{.ResourceGroup}}
-        resource_group_location: {{.ResourceGroupLocation}}
-      environmentPath: "{{$clusterName}} environment"
+  - name: {{ .Prefix }}{{$clusterName}}
+    type: udm.Application
+    children:
+    - name: '1.0.0'
+      type: udm.DeploymentPackage
+      deployables:
+      - name: {{ .Prefix }}{{$clusterName}}
+        type: terraform.Module
+        file: !file ../terraform-azure-basic-aks-cluster
+        inputVariables:
+          cluster_name: {{$clusterName}}
+          subscription_id: {{.SubscriptionID}}
+          client_id: {{.ClientID}}
+          client_secret: {{.ClientSecret}}
+          tenant_id: {{.TenantID}}
+          resource_group: {{.ResourceGroup}}
+          resource_group_location: {{.ResourceGroupLocation}}
+        environmentPath: "{{$clusterName}} environment"

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -115,11 +115,6 @@ spec:
     prompt: "Enter you Azure subscription id:"
     promptIf: ProvisionCluster
 
-  - name: TenantID
-    type: Input
-    prompt: "Enter your Azure tenant id:"
-    promptIf: ProvisionCluster
-
   - name: ClientID
     type: Input
     prompt: "Enter your Azure client id:"
@@ -128,6 +123,11 @@ spec:
   - name: ClientSecret
     type: SecretInput
     prompt: "Enter your Azure client secret:"
+    promptIf: ProvisionCluster
+
+  - name: TenantID
+    type: Input
+    prompt: "Enter your Azure tenant id:"
     promptIf: ProvisionCluster
 
   # ############################################################################

--- a/azure/microservice-ecommerce/terraform/aks/main.tf
+++ b/azure/microservice-ecommerce/terraform/aks/main.tf
@@ -1,8 +1,3 @@
-resource "azurerm_resource_group" "k8s" {
-  name     = "${var.resource_group_name}"
-  location = "${var.location}"
-}
-
 resource "tls_private_key" "key" {
   algorithm   = "RSA"
   ecdsa_curve = "P224"
@@ -11,8 +6,8 @@ resource "tls_private_key" "key" {
 
 resource "azurerm_kubernetes_cluster" "k8s" {
   name                = "${var.cluster_name}"
-  location            = "${azurerm_resource_group.k8s.location}"
-  resource_group_name = "${azurerm_resource_group.k8s.name}"
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
   dns_prefix          = "${var.dns_prefix}"
 
   agent_pool_profile {

--- a/azure/microservice-ecommerce/terraform/main.tf
+++ b/azure/microservice-ecommerce/terraform/main.tf
@@ -14,14 +14,14 @@ resource "azurerm_resource_group" "k8s" {
 module "vpc" {
   source              = "./vpc"
   name                = "${var.cluster_name}"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
+  location            = "${azurerm_resource_group.k8s.location}"
+  resource_group_name = "${azurerm_resource_group.k8s.name}"
 }
 
 module "aks" {
   source              = "./aks"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
+  location            = "${azurerm_resource_group.k8s.location}"
+  resource_group_name = "${azurerm_resource_group.k8s.name}"
   cluster_name        = "${var.cluster_name}"
   vm_size             = "${var.vm_size}"
   node_count          = "${var.node_count}"

--- a/azure/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-invoice-mysql
             type: k8s.ResourcesFile
             file: !file ../kubernetes/invoice/invoice-mysql.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-invoice
         type: udm.Application
         children:
@@ -26,6 +28,10 @@ spec:
           - name: {{$app}}-invoice-deployment
             type: k8s.ResourcesFile
             file: !file ../kubernetes/invoice/invoice-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-invoice-svc
             type: k8s.ResourcesFile
             file: !file ../kubernetes/invoice/invoice-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/azure/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-notification-mongodb
             type: k8s.ResourcesFile
             file: !file ../kubernetes/notification/notification-mongodb.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-notification
         type: udm.Application
         children:
@@ -26,6 +28,10 @@ spec:
           - name: {{$app}}-invoice-notification
             type: k8s.ResourcesFile
             file: !file ../kubernetes/notification/notification-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-notification-svc
             type: k8s.ResourcesFile
             file: !file ../kubernetes/notification/notification-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/azure/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-store-mysql
             type: k8s.ResourcesFile
             file: !file ../kubernetes/store/store-mysql.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-registry
         type: udm.Application
         children:
@@ -26,9 +28,13 @@ spec:
           - name: {{$app}}-application-config
             type: k8s.ResourcesFile
             file: !file ../kubernetes/registry/application-configmap.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-jhipster-registry
             type: k8s.ResourcesFile
             file: !file ../kubernetes/registry/jhipster-registry.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-store
         type: udm.Application
         children:
@@ -38,6 +44,10 @@ spec:
           - name: {{$app}}-store-deployment
             type: k8s.ResourcesFile
             file: !file ../kubernetes/store/store-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-store-svc
             type: k8s.ResourcesFile
             file: !file ../kubernetes/store/store-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
           inputVariables:
             name: {{$app}}
             resource_group_name: {{.ResourceGroup}}
-            cluster_name: {{.ClusterName}}
+            cluster_name: {{$clusterName}}
             location: {{.AKSRegion}}
             client_id: {{.ClientID}}
             client_secret: !value ClientSecret

--- a/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -29,24 +29,7 @@ spec:
             client_secret: !value ClientSecret
             subscription_id: {{.SubscriptionID}}
             tenant_id: {{.TenantID}}
-          boundTemplates:
-          - "../azure-aks-{{$clusterName}}"
-          - "../azure-aks-{{$clusterName}}-env"
-
-        templates:
-        # creates the required XLD infrastructure entries
-        - name: azure-aks-{{$clusterName}}
-          type: template.k8s.Master
-          apiServerURL: '{{"{{%outputVariables.host%}}"}}'
-          skipTLS: true
-          token: '{{"{{%outputVariables.password%}}"}}'
-          instanceName: {{$app}}/azure-aks-{{$clusterName}}
-        # creates a new environment for Kubernetes deployments
-        - name: azure-aks-{{$clusterName}}-env
-          type: template.udm.Environment
-          members:
-          - "../azure-aks-{{$clusterName}}"
-          instanceName: {{$app}}/azure-aks-{{$clusterName}}
+          environmentPath: azure-aks-{{$clusterName}}
 
 {{end}}
   - name: K8S

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -96,7 +96,7 @@ spec:
         - name: Tag namespace
           type: xld.UpdateCIProperty
           server: XL Deploy
-          ciID: Infrastructure/{{$app}}/{{$app}}-AKSCluster/{{.Namespace}}
+          ciID: Infrastructure/{{$app}}/{{.ClusterName}}-AKSCluster/{{.Namespace}}
           ciProperty: tags
           propertyValue: '[ "{{.Namespace}}" ]'
       {{end}}

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -96,7 +96,7 @@ spec:
         - name: Tag namespace
           type: xld.UpdateCIProperty
           server: XL Deploy
-          ciID: Infrastructure/{{$app}}/{{.ClusterName}}-AKSCluster/{{.Namespace}}
+          ciID: Infrastructure/{{$app}}/{{$clusterName}}-AKSCluster/{{.Namespace}}
           ciProperty: tags
           propertyValue: '[ "{{.Namespace}}" ]'
       {{end}}

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -155,7 +155,7 @@ spec:
           server: XL Deploy
           numberOfContinueRetrials: 100
           pollingInterval: 10
-          ciId: Infrastructure/{{$app}}/{{$app}}-AKSCluster
+          ciId: Infrastructure/{{$app}}/{{$clusterName}}-AKSCluster
           taskName: describeService
           variableMapping:
             pythonScript.xlDeployTaskId: ${taskId}

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -86,10 +86,19 @@ spec:
       tasks:
       {{if .ProvisionCluster }}
       - name: Deploy {{.Namespace}} namespace
-        type: xldeploy.Deploy
-        server: XL Deploy
-        deploymentPackage: {{$app}}/K8S/{{$app}}-namespace/1.0.0
-        deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+        type: xlrelease.SequentialGroup
+        tasks:
+        - name: Deploy namespace
+          type: xldeploy.Deploy
+          server: XL Deploy
+          deploymentPackage: {{$app}}/K8S/{{$app}}-namespace/1.0.0
+          deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+        - name: Tag namespace
+          type: xld.UpdateCIProperty
+          server: XL Deploy
+          ciID: Infrastructure/{{$app}}/{{$app}}-AKSCluster/{{.Namespace}}
+          ciProperty: tags
+          propertyValue: '[ "{{.Namespace}}" ]'
       {{end}}
       - name: Deploy stateful services
         type: xlrelease.ParallelGroup

--- a/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -155,7 +155,7 @@ spec:
           server: XL Deploy
           numberOfContinueRetrials: 100
           pollingInterval: 10
-          ciId: Infrastructure/{{$app}}/azure-aks-{{$clusterName}}
+          ciId: Infrastructure/{{$app}}/{{$app}}-AKSCluster
           taskName: describeService
           variableMapping:
             pythonScript.xlDeployTaskId: ${taskId}

--- a/gcp/basic-gke-cluster/xebialabs/gcp-basic-gke-cluster.yaml.tmpl
+++ b/gcp/basic-gke-cluster/xebialabs/gcp-basic-gke-cluster.yaml.tmpl
@@ -3,64 +3,54 @@
 apiVersion: xl-deploy/v1
 kind: Infrastructure
 spec:
-- name: {{ .Prefix }}terraform-host
-  type: overthere.LocalHost
-  os: UNIX
+- name: {{ $clusterName }}
+  type: core.Directory
   children:
-  - name: terraform-client
-    type: terraform.TerraformClient
-    path: '/usr/local/bin'
-    workingDirectory: '/tmp/{{ .Prefix }}terraform'
+  - name: {{ .Prefix }}terraform-host
+    type: overthere.LocalHost
+    os: UNIX
+    children:
+    - name: terraform-client
+      type: terraform.TerraformClient
+      path: '/usr/local/bin'
+      workingDirectory: '/tmp/{{ .Prefix }}terraform'
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Environments
 spec:
-- name: {{ .Prefix }}terraform
-  type: udm.Environment
-  members:
-  - ~Infrastructure/{{ .Prefix }}terraform-host/terraform-client
+- name: {{ $clusterName }}
+  type: core.Directory
+  children:
+  - name: {{ .Prefix }}terraform
+    type: udm.Environment
+    members:
+    - ~Infrastructure/{{ $clusterName }}/{{ .Prefix }}terraform-host/terraform-client
 
 ---
 
 apiVersion: xl-deploy/v1
 kind: Applications
 spec:
-- name: {{ .Prefix }}{{$clusterName}}
-  type: udm.Application
+- name: {{ $clusterName }}
+  type: core.Directory
   children:
-  - name: '1.0.0'
-    type: udm.DeploymentPackage
-    deployables:
-    - name: {{ .Prefix }}{{$clusterName}}
-      type: terraform.Module
-      file: !file ../terraform-gcp-basic-gke-cluster
-      inputVariables:
-        project_id: {{.GCPProjectID}}
-        name: {{$clusterName}}
-        region: {{.GCPRegion}}
-        gke_master_user: {{.K8SMasterUser}}
-        gke_master_pass: {{.K8SMasterPassword}}
-        gke_num_nodes: {{.GKENumNodes}}
-        gke_node_machine_type: {{.GKENodeMachineType}}
-      boundTemplates:
-      - "../{{$clusterName}} infrastructure"
-      - "../{{$clusterName}} environment"
-    templates:
-    - name: "{{$clusterName}} infrastructure"
-      type: template.k8s.Master
-      instanceName: {{$clusterName}}
-      apiServerURL: 'https://{{"{{%outputVariables.endpoint%}}"}}'
-      username: {{.K8SMasterUser}}
-      password: {{.K8SMasterPassword}}
-      skipTLS: true
-      children:
-      - name: default
-        type: template.k8s.Namespace
-    - name: "{{$clusterName}} environment"
-      type: template.udm.Environment
-      instanceName: {{$clusterName}}
-      members:
-      - "../{{$clusterName}} infrastructure"
-      - "../{{$clusterName}} infrastructure/default"
+  - name: {{ .Prefix }}{{$clusterName}}
+    type: udm.Application
+    children:
+    - name: '1.0.0'
+      type: udm.DeploymentPackage
+      deployables:
+      - name: {{ .Prefix }}{{$clusterName}}
+        type: terraform.Module
+        file: !file ../terraform-gcp-basic-gke-cluster
+        inputVariables:
+          project_id: {{.GCPProjectID}}
+          name: {{$clusterName}}
+          region: {{.GCPRegion}}
+          gke_master_user: {{.K8SMasterUser}}
+          gke_master_pass: {{.K8SMasterPassword}}
+          gke_num_nodes: {{.GKENumNodes}}
+          gke_node_machine_type: {{.GKENodeMachineType}}
+        environmentPath: "{{$clusterName}} environment"

--- a/gcp/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-invoice-mysql
             type: k8s.ResourcesFile
             file: !file ../kubernetes/invoice/invoice-mysql.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-invoice
         type: udm.Application
         children:
@@ -26,6 +28,10 @@ spec:
           - name: {{$app}}-invoice-deployment
             type: k8s.ResourcesFile
             file: !file ../kubernetes/invoice/invoice-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-invoice-svc
             type: k8s.ResourcesFile
             file: !file ../kubernetes/invoice/invoice-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/gcp/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-notification-mongodb
             type: k8s.ResourcesFile
             file: !file ../kubernetes/notification/notification-mongodb.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-notification
         type: udm.Application
         children:
@@ -26,6 +28,10 @@ spec:
           - name: {{$app}}-invoice-notification
             type: k8s.ResourcesFile
             file: !file ../kubernetes/notification/notification-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-notification-svc
             type: k8s.ResourcesFile
             file: !file ../kubernetes/notification/notification-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/gcp/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-store-mysql
             type: k8s.ResourcesFile
             file: !file ../kubernetes/store/store-mysql.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-registry
         type: udm.Application
         children:
@@ -26,9 +28,13 @@ spec:
           - name: {{$app}}-application-config
             type: k8s.ResourcesFile
             file: !file ../kubernetes/registry/application-configmap.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-jhipster-registry
             type: k8s.ResourcesFile
             file: !file ../kubernetes/registry/jhipster-registry.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-store
         type: udm.Application
         children:
@@ -38,6 +44,10 @@ spec:
           - name: {{$app}}-store-deployment
             type: k8s.ResourcesFile
             file: !file ../kubernetes/store/store-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-store-svc
             type: k8s.ResourcesFile
             file: !file ../kubernetes/store/store-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/gcp/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/xld-terraform-apps.yaml.tmpl
@@ -26,25 +26,7 @@ spec:
             region: {{.GCPRegion}}
             gke_master_user: {{.K8SMasterUser}}
             gke_master_pass: {{.K8SMasterPassword}}
-          boundTemplates:
-          - "../gcp-gke-{{$clusterName}}"
-          - "../gcp-gke-{{$clusterName}}-env"
-
-        templates:
-        # creates the required XLD infrastructure entries
-        - name: gcp-gke-{{$clusterName}}
-          type: template.k8s.Master
-          username: {{.K8SMasterUser}}
-          password: {{.K8SMasterPassword}}
-          apiServerURL: 'https://{{"{{%outputVariables.endpoint%}}"}}'
-          skipTLS: true
-          instanceName: {{$app}}/gcp-gke-{{$clusterName}}
-        # creates a new environment for Kubernetes deployments
-        - name: gcp-gke-{{$clusterName}}-env
-          type: template.udm.Environment
-          members:
-          - "../gcp-gke-{{$clusterName}}"
-          instanceName: {{$app}}/gcp-gke-{{$clusterName}}
+          environmentPath: gcp-gke-{{$clusterName}}
 
 {{end}}
   - name: K8S

--- a/gcp/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -87,10 +87,19 @@ spec:
       tasks:
       {{if .ProvisionCluster }}
       - name: Deploy {{.Namespace}} namespace
-        type: xldeploy.Deploy
-        server: XL Deploy
-        deploymentPackage: {{$app}}/K8S/{{$app}}-namespace/1.0.0
-        deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+        type: xlrelease.SequentialGroup
+        tasks:
+        - name: Deploy namespace
+          type: xldeploy.Deploy
+          server: XL Deploy
+          deploymentPackage: {{$app}}/K8S/{{$app}}-namespace/1.0.0
+          deploymentEnvironment: Environments/{{$app}}/{{$appEnv}}
+        - name: Tag namespace
+          type: xld.UpdateCIProperty
+          server: XL Deploy
+          ciID: Infrastructure/{{$app}}/gke-{{$app}}-cluster-GKECluster/{{.Namespace}}
+          ciProperty: tags
+          propertyValue: '[ "{{.Namespace}}" ]'
       {{end}}
       - name: Deploy stateful services
         type: xlrelease.ParallelGroup
@@ -147,7 +156,7 @@ spec:
           server: XL Deploy
           numberOfContinueRetrials: 100
           pollingInterval: 10
-          ciId: Infrastructure/{{$app}}/gcp-gke-{{$clusterName}}
+          ciId: Infrastructure/{{$app}}/gke-{{$app}}-cluster-GKECluster
           taskName: describeService
           variableMapping:
             pythonScript.xlDeployTaskId: ${taskId}


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [x] The Travis CI for the PR is green
- [x] The blueprint has been reviewed by someone else in the team.
- [x] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [x] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [x] The blueprint works on Linux, Mac and Windows.
