### PR TITLE
fix issues with AWS MS blueprint

### DIFF
--- a/aws/microservice-ecommerce/blueprint.yaml
+++ b/aws/microservice-ecommerce/blueprint.yaml
@@ -75,8 +75,9 @@ spec:
   - name: Namespace
     type: Input
     prompt: What is the name of the namespace? This should be same as the one used in Kubernetes files.
-    promptIf: !expr "!ProvisionCluster"
     default: xl-demo
+    value: !expr "ProvisionCluster ? 'xl-demo' : ''"
+
   - name: StoreAdminUsername
     value: admin
   - name: StoreAdminPassword

--- a/aws/microservice-ecommerce/xebialabs/xld-cloudformation-apps.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xld-cloudformation-apps.yaml.tmpl
@@ -80,6 +80,7 @@ spec:
           capabilities:
           - CAPABILITY_IAM
           - CAPABILITY_NAMED_IAM
+          environmentPath: aws-eks-{{$app}}
           inputVariables:
             ProjectName: {{$app}}
             VPCStackName: {{$app}}-eks-vpc
@@ -95,7 +96,6 @@ spec:
           capabilities:
           - CAPABILITY_IAM
           - CAPABILITY_NAMED_IAM
-          environmentPath: aws-eks-{{$app}}
           inputVariables:
             ProjectName: {{$app}}
             VPCStackName: {{$app}}-eks-vpc
@@ -128,7 +128,7 @@ spec:
       - name: '1.0.0'
         type: udm.DeploymentPackage
         deployables:
-        - name: xl-demo
+        - name: {{.Namespace}}
           type: k8s.NamespaceSpec
-          namespaceName: 'xl-demo'
+          namespaceName: '{{.Namespace}}'
 {{end}}

--- a/aws/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xld-kubernetes-invoice-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-invoice-mysql
             type: k8s.ResourcesFile
             file: !file ../invoice/build/kubernetes/invoice-mysql.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-invoice
         type: udm.Application
         children:
@@ -26,6 +28,10 @@ spec:
           - name: {{$app}}-invoice-deployment
             type: k8s.ResourcesFile
             file: !file ../invoice/build/kubernetes/invoice-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-invoice-svc
             type: k8s.ResourcesFile
             file: !file ../invoice/build/kubernetes/invoice-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/aws/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xld-kubernetes-notification-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-notification-mongodb
             type: k8s.ResourcesFile
             file: !file ../notification/build/kubernetes/notification-mongodb.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-notification
         type: udm.Application
         children:
@@ -26,6 +28,10 @@ spec:
           - name: {{$app}}-invoice-notification
             type: k8s.ResourcesFile
             file: !file ../notification/build/kubernetes/notification-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-notification-svc
             type: k8s.ResourcesFile
             file: !file ../notification/build/kubernetes/notification-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/aws/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xld-kubernetes-store-app.yaml.tmpl
@@ -17,6 +17,8 @@ spec:
           - name: {{$app}}-store-mysql
             type: k8s.ResourcesFile
             file: !file ../store/build/kubernetes/store-mysql.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-registry
         type: udm.Application
         children:
@@ -26,9 +28,13 @@ spec:
           - name: {{$app}}-application-config
             type: k8s.ResourcesFile
             file: !file ../registry/kubernetes/application-configmap.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-jhipster-registry
             type: k8s.ResourcesFile
             file: !file ../registry/kubernetes/jhipster-registry.yml
+            tags: 
+            - {{.Namespace}}
       - name: {{$app}}-store
         type: udm.Application
         children:
@@ -38,6 +44,10 @@ spec:
           - name: {{$app}}-store-deployment
             type: k8s.ResourcesFile
             file: !file ../store/build/kubernetes/store-deployment.yml
+            tags: 
+            - {{.Namespace}}
           - name: {{$app}}-store-svc
             type: k8s.ResourcesFile
             file: !file ../store/build/kubernetes/store-service.yml
+            tags: 
+            - {{.Namespace}}

--- a/aws/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
@@ -22,11 +22,7 @@ spec:
       requiresValue: false
       showOnReleaseStart: false
       value:
-        {{- if .ProvisionCluster }}
-        namespace: xl-demo
-        {{- else}}
         namespace: {{.Namespace}}
-        {{- end}}
         serviceName: store
     - key: lbHostnameOrIp
       type: xlrelease.StringVariable
@@ -146,11 +142,20 @@ spec:
       type: xlrelease.Phase
       tasks:
       {{if .ProvisionCluster }}
-      - name: Deploy xl-demo namespace
-        type: xldeploy.Deploy
-        server: XL Deploy
-        deploymentPackage: {{$app}}/K8S/{{$app}}-namespace/1.0.0
-        deploymentEnvironment: Environments/{{$app}}/aws-eks-{{$app}}
+      - name: Deploy {{.Namespace}} namespace
+        type: xlrelease.SequentialGroup
+        tasks:
+        - name: Deploy namespace
+          type: xldeploy.Deploy
+          server: XL Deploy
+          deploymentPackage: {{$app}}/K8S/{{$app}}-namespace/1.0.0
+          deploymentEnvironment: Environments/{{$app}}/aws-eks-{{$app}}
+        - name: Tag namespace
+          type: xld.UpdateCIProperty
+          server: XL Deploy
+          ciID: Infrastructure/{{$app}}/{{$app}}-master-EKSCluster/{{.Namespace}}
+          ciProperty: tags
+          propertyValue: '[ "{{.Namespace}}" ]'
       {{end}}
       - name: Deploy stateful services
         type: xlrelease.ParallelGroup
@@ -208,7 +213,7 @@ spec:
           numberOfContinueRetrials: 100
           pollingInterval: 10
           {{if .ProvisionCluster }}
-          ciId: Infrastructure/{{$app}}/eks-cluster
+          ciId: Infrastructure/{{$app}}/{{$app}}-master-EKSCluster
           {{else}}
           ciId: Infrastructure/{{$app}}/eks-{{$clusterName}}
           {{end}}

--- a/aws/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
+++ b/aws/microservice-ecommerce/xebialabs/xlr-pipeline-destroy.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
           deployedApplication: Environments/{{$app}}/aws-eks-{{$app}}/{{$app}}-notification-mongodb
       {{if .ProvisionCluster }}
       # Un-provision namespace
-      - name: Undeploy xl-demo namespace
+      - name: Undeploy {{.Namespace}} namespace
         type: xldeploy.Undeploy
         server: XL Deploy
         deployedApplication: Environments/{{$app}}/aws-eks-{{$app}}/{{$app}}-namespace


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
