### PR TITLE
LOVE 1097 - Blueprint skeleton

### DIFF
--- a/Releasefile.groovy
+++ b/Releasefile.groovy
@@ -9,6 +9,7 @@ xlr {
     variables {
       stringVariable('BLUEPRINTS_VERSION') {
         label 'Blueprints Version'
+        description 'The release version to use, should be x.x.x notation'
       }
       stringVariable('GIT_BRANCH') {
         label 'Git branch'

--- a/blueprint-skeleton/README.md
+++ b/blueprint-skeleton/README.md
@@ -1,0 +1,33 @@
+# Blueprint skeleton
+
+This blueprint generates a blueprint skeleton of directories and files in order for you to create your own blueprint.
+
+## Usage
+
+To use this blueprint, run `xl blueprint` in an empty directory and select:
+
+    blueprint-skeleton
+
+## Minimum required versions
+
+This blueprint version requires at least the following versions of the specified tools to work properly:
+
+* XL CLI: Version 9.0.0
+
+## Prerequisites
+
+There are no prerequisites
+
+## Information required
+
+This blueprint requires:
+
+1. The name of the blueprint in _kebabcase_ (lowercase letters, numbers and hyphens)
+2. A description of the blueprint
+3. Instructions for your users to follow after they have run your blueprint
+
+## Output
+
+This blueprint will output:
+
+* A skeleton blueprint directory and files for you to write your own blueprint

--- a/blueprint-skeleton/README.md.tmpl
+++ b/blueprint-skeleton/README.md.tmpl
@@ -1,0 +1,64 @@
+# _BLUEPRINT_NAME_
+
+## Introduction
+
+Explain what your blueprint does
+
+## Before you get started
+
+If you're new to XebiaLabs blueprints, check out:
+
+* [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
+* [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
+* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
+
+## Usage
+
+To use this blueprint, run:
+
+```plain
+xl blueprint
+```
+
+Explain how the user will execute your blueprint (especially if it needs to be used offline)
+
+## Tools and technologies
+
+This blueprint includes the following tools and technologies:
+
+* _TOOL1_
+* _TOOL2_
+
+## Minimum required versions
+
+This blueprint version requires at least the following versions of the specified tools to work properly:
+
+* XL Deploy: Version 9.0.0
+* XL Release: Version 9.0.0
+* XL CLI: Version 9.0.0
+
+Remove whatever is not applicable
+
+## Prerequisites
+
+To run the YAML that this blueprint generates, you need:
+
+* XebiaLabs Deployment Automation up and running
+* _OTHER_PREREQUISITE_
+
+## Information required
+
+What important data will your blueprint be asking for
+
+## Output
+
+This blueprint will output:
+
+* _ITEM1_
+* _ITEM2_
+
+## Labels
+
+* _LABEL1_
+* _LABEL2_
+*

--- a/blueprint-skeleton/README.md.tmpl
+++ b/blueprint-skeleton/README.md.tmpl
@@ -1,8 +1,8 @@
-# _BLUEPRINT_NAME_
+# {{.BlueprintName | replace "-" " " | title}}
 
 ## Introduction
 
-Explain what your blueprint does
+{{.Description}
 
 ## Before you get started
 

--- a/blueprint-skeleton/README.md.tmpl
+++ b/blueprint-skeleton/README.md.tmpl
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-{{.Description}
+{{.Description}}
 
 ## Before you get started
 

--- a/blueprint-skeleton/USAGE-skeleton.md.tmpl
+++ b/blueprint-skeleton/USAGE-skeleton.md.tmpl
@@ -1,0 +1,16 @@
+# Blueprint skeleton
+
+Now that you've created your blueprint skeleton, there are a few more steps:
+
+1. If your blueprint is related to one of technologies (e.g. `aws`), move it to that directory before committing it
+2. If your blueprint is for a whole new technology, create that directory, then move your blueprint to that directory before committing it
+3. When you're done reading this file, delete it, as it should not be part of your blueprint
+
+The files in this skeleton make up a basic blueprint with the most common elements. For more detail, refer to the online documentation:
+* [Blueprint YAML format](https://docs.xebialabs.com/xl-platform/concept/blueprint-yaml-format.html)
+* [Go Templates](https://golang.org/pkg/text/template/)
+* [Using Go Templates](https://blog.gopheracademy.com/advent-2017/using-go-templates/)
+
+## Notes:
+
+In the blueprints, all places where you should substitute your own values is marked like `_VALUE_HERE_`.

--- a/blueprint-skeleton/__test__/answers.yaml
+++ b/blueprint-skeleton/__test__/answers.yaml
@@ -1,0 +1,3 @@
+BlueprintName: my-first-blueprint
+Instructions: Read xebialabs/USAGE.md to learn how to use this blueprint.
+Description: A useful, but short description of what this blueprint does

--- a/blueprint-skeleton/__test__/answers.yaml
+++ b/blueprint-skeleton/__test__/answers.yaml
@@ -1,3 +1,3 @@
 BlueprintName: my-first-blueprint
-Instructions: Read xebialabs/USAGE.md to learn how to use this blueprint.
 Description: A useful, but short description of what this blueprint does
+Instructions: Read xebialabs/USAGE.md to learn how to use this blueprint.

--- a/blueprint-skeleton/__test__/answers.yaml.tmpl
+++ b/blueprint-skeleton/__test__/answers.yaml.tmpl
@@ -1,0 +1,5 @@
+AppName: MyApp
+SomeCondition: true
+Username: admin
+Password: admin
+MultiSelect: simple-value

--- a/blueprint-skeleton/__test__/test.yaml
+++ b/blueprint-skeleton/__test__/test.yaml
@@ -1,0 +1,21 @@
+answers-file: answers.yaml
+expected-files:
+- __test__/test.yaml
+- __test__/answers.yaml
+- README.md.tmpl
+- blueprint.yaml
+- xebialabs.yaml
+- xebialabs/USAGE.md.tmpl
+- xebialabs/xld-infra-env.yaml.tmpl
+- xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+- xebialabs/xlr-pipeline-destroy.yaml.tmpl
+not-expected-files:
+- __test__/test.yaml.tmpl
+- __test__/answers.yaml.tmpl
+- README.md
+- blueprint.yaml.tmpl
+- xebialabs.yaml.tmpl
+- xebialabs/USAGE.md
+- xebialabs/xld-infra-env.yaml
+- xebialabs/xlr-pipeline-ci-cd.yaml
+- xebialabs/xlr-pipeline-destroy.yaml

--- a/blueprint-skeleton/__test__/test.yaml
+++ b/blueprint-skeleton/__test__/test.yaml
@@ -3,6 +3,7 @@ expected-files:
 - __test__/test.yaml
 - __test__/answers.yaml
 - README.md
+- USAGE-skeleton.md
 - blueprint.yaml
 - xebialabs.yaml
 - xebialabs/USAGE.md.tmpl
@@ -16,6 +17,7 @@ not-expected-files:
 - blueprint.yaml.tmpl
 - xebialabs.yaml.tmpl
 - xebialabs/USAGE.md
+- xebialabs/xld-apps.yaml
 - xebialabs/xld-infra-env.yaml
 - xebialabs/xlr-pipeline-ci-cd.yaml
 - xebialabs/xlr-pipeline-destroy.yaml

--- a/blueprint-skeleton/__test__/test.yaml
+++ b/blueprint-skeleton/__test__/test.yaml
@@ -2,7 +2,7 @@ answers-file: answers.yaml
 expected-files:
 - __test__/test.yaml
 - __test__/answers.yaml
-- README.md.tmpl
+- README.md
 - blueprint.yaml
 - xebialabs.yaml
 - xebialabs/USAGE.md.tmpl
@@ -12,7 +12,7 @@ expected-files:
 not-expected-files:
 - __test__/test.yaml.tmpl
 - __test__/answers.yaml.tmpl
-- README.md
+- README.md.tmpl
 - blueprint.yaml.tmpl
 - xebialabs.yaml.tmpl
 - xebialabs/USAGE.md

--- a/blueprint-skeleton/__test__/test.yaml.tmpl
+++ b/blueprint-skeleton/__test__/test.yaml.tmpl
@@ -1,5 +1,9 @@
 answers-file: answers.yaml
 expected-files:
+- xebialabs.yaml
+- README.md
 - xebialabs/USAGE.md
-non-expected-files:
-- xebialabs/USAGE.md
+- xebialabs/xld-apps.yaml
+- xebialabs/xld-infra-env.yaml
+- xebialabs/xlr-pipeline-ci-cd.yaml
+- xebialabs/xlr-pipeline-destroy.yaml

--- a/blueprint-skeleton/__test__/test.yaml.tmpl
+++ b/blueprint-skeleton/__test__/test.yaml.tmpl
@@ -1,5 +1,5 @@
 answers-file: answers.yaml
 expected-files:
-- xebialabs/USAGE-{{.BlueprintName}}.md
+- xebialabs/USAGE.md
 non-expected-files:
 - xebialabs/USAGE.md

--- a/blueprint-skeleton/__test__/test.yaml.tmpl
+++ b/blueprint-skeleton/__test__/test.yaml.tmpl
@@ -1,0 +1,5 @@
+answers-file: answers.yaml
+expected-files:
+- xebialabs/USAGE-{{.BlueprintName}}.md
+non-expected-files:
+- xebialabs/USAGE.md

--- a/blueprint-skeleton/blueprint.yaml
+++ b/blueprint-skeleton/blueprint.yaml
@@ -1,0 +1,42 @@
+apiVersion: xl/v2
+kind: Blueprint
+
+metadata:
+  name: Blueprint-Skeleton-Generator
+  description: |
+    Creates a blueprint skeleton directory
+  author: XebiaLabs
+  version: 2.0
+  instructions: # TODO
+
+spec:
+  parameters:
+  - name: BlueprintName
+    type: Input
+    prompt: "Name of the blueprint:"
+    description: Use kebabcase (lowercase letters, number and hypens only) e.g. this-useful-blueprint
+    validate: !expr "regex('^[a-z0-9][a-z0-9-]+[a-z0-9]$', BlueprintName)"
+
+  - name: Instructions
+    type: Input
+    prompt: "Usage instructions for when blueprint finishes:"
+
+  - name: Description
+    type: Input
+    prompt: "Brief description of the blueprint:"
+
+  files:
+  - path: __test__/test.yaml.tmpl
+  - path: __test__/answers.yaml
+  - path: blueprint.yaml.tmpl
+  - path: README.md.tmpl
+    renameTo: README.md.tmpl
+  - path: xebialabs.yaml
+  - path: xebialabs/USAGE.md.tmpl
+    renameTo: xebialabs/USAGE.md.tmpl
+  - path: xebialabs/xld-infra-env.yaml.tmpl
+    renameTo: xebialabs/xld-infra-env.yaml.tmpl
+  - path: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+    renameTo: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+  - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl
+    renameTo: xebialabs/xlr-pipeline-destroy.yaml.tmpl

--- a/blueprint-skeleton/blueprint.yaml
+++ b/blueprint-skeleton/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     Creates a blueprint skeleton directory
   author: XebiaLabs
   version: 2.0
-  instructions: # TODO
+  instructions: Read USAGE-skeleton.md for more information on how to write your own blueprint
 
 spec:
   parameters:
@@ -17,13 +17,13 @@ spec:
     description: Use kebabcase (lowercase letters, number and hypens only) e.g. this-useful-blueprint
     validate: !expr "regex('^[a-z0-9][a-z0-9-]+[a-z0-9]$', BlueprintName)"
 
-  - name: Instructions
-    type: Input
-    prompt: "Usage instructions for when blueprint finishes:"
-
   - name: Description
     type: Input
     prompt: "Brief description of the blueprint:"
+
+  - name: Instructions
+    type: Input
+    prompt: "Usage instructions for when blueprint finishes:"
 
   files:
   - path: __test__/test.yaml.tmpl
@@ -31,7 +31,9 @@ spec:
   - path: blueprint.yaml.tmpl
   - path: README.md.tmpl
   - path: xebialabs.yaml
+  - path: USAGE-skeleton.md.tmpl
   - path: xebialabs/USAGE.md.tmpl.tmpl
+  - path: xebialabs/xld-apps.yaml.tmpl.tmpl
   - path: xebialabs/xld-infra-env.yaml.tmpl.tmpl
   - path: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl.tmpl
   - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl.tmpl

--- a/blueprint-skeleton/blueprint.yaml
+++ b/blueprint-skeleton/blueprint.yaml
@@ -27,7 +27,7 @@ spec:
 
   files:
   - path: __test__/test.yaml.tmpl
-  - path: __test__/answers.yaml
+  - path: __test__/answers.yaml.tmpl
   - path: blueprint.yaml.tmpl
   - path: README.md.tmpl
     renameTo: README.md.tmpl

--- a/blueprint-skeleton/blueprint.yaml
+++ b/blueprint-skeleton/blueprint.yaml
@@ -30,13 +30,8 @@ spec:
   - path: __test__/answers.yaml.tmpl
   - path: blueprint.yaml.tmpl
   - path: README.md.tmpl
-    renameTo: README.md.tmpl
   - path: xebialabs.yaml
-  - path: xebialabs/USAGE.md.tmpl
-    renameTo: xebialabs/USAGE.md.tmpl
-  - path: xebialabs/xld-infra-env.yaml.tmpl
-    renameTo: xebialabs/xld-infra-env.yaml.tmpl
-  - path: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
-    renameTo: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
-  - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl
-    renameTo: xebialabs/xlr-pipeline-destroy.yaml.tmpl
+  - path: xebialabs/USAGE.md.tmpl.tmpl
+  - path: xebialabs/xld-infra-env.yaml.tmpl.tmpl
+  - path: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl.tmpl
+  - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl.tmpl

--- a/blueprint-skeleton/blueprint.yaml.tmpl
+++ b/blueprint-skeleton/blueprint.yaml.tmpl
@@ -1,0 +1,27 @@
+apiVersion: xl/v2
+kind: Blueprint
+
+metadata:
+  name: Blueprint-Skeleton-Generator
+  description: |
+    {{.Description}}
+  author: XebiaLabs
+  version: 2.0
+  instructions: {{.Instructions}}
+
+spec:
+  parameters:
+  - name: AppName
+    type: Input
+    prompt: What is the name of the application?
+
+  files:
+  - path: xebialabs.yaml
+  - path: xebialabs/USAGE.md.tmpl
+  - path: xebialabs/xld-infra-env.yaml.tmpl
+  - path: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
+  - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl
+
+# Issues:
+# - Need to delete the secrets.xlvals file
+# - Need to delete the values.xlvals file

--- a/blueprint-skeleton/blueprint.yaml.tmpl
+++ b/blueprint-skeleton/blueprint.yaml.tmpl
@@ -15,13 +15,41 @@ spec:
     type: Input
     prompt: What is the name of the application?
 
+  - name: SomeCondition
+    type: Confirm
+    prompt: Do you want this condition to be true?
+    description: "This will be used later in the blueprint and in xlr-pipeline-ci-cd.yaml.tmpl"
+    default: true
+
+  - name: HiddenDerivedValue
+    type: Input
+    value: !expr "'prefix-' + AppName + '-suffix'"
+
+  - name: Username
+    type: Input
+    prompt: What is the username?
+    promptIf: !expr "SomeCondition"
+    saveInXlvals: true
+
+  - name: Password
+    type: SecretInput
+    prompt: What is the password?
+    promptIf: !expr "SomeCondition"
+
+  - name: MultiSelect
+    type: Select
+    prompt: "Choose one:"
+    options:
+    - simple-option
+    - label: Nicer option
+      value: simple-value
+
   files:
   - path: xebialabs.yaml
+  - path: README.md
   - path: xebialabs/USAGE.md.tmpl
+    writeIf: !expr "SomeCondition"
+  - path: xebialabs/xld-apps.yaml.tmpl
   - path: xebialabs/xld-infra-env.yaml.tmpl
   - path: xebialabs/xlr-pipeline-ci-cd.yaml.tmpl
   - path: xebialabs/xlr-pipeline-destroy.yaml.tmpl
-
-# Issues:
-# - Need to delete the secrets.xlvals file
-# - Need to delete the values.xlvals file

--- a/blueprint-skeleton/blueprint.yaml.tmpl
+++ b/blueprint-skeleton/blueprint.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: xl/v2
 kind: Blueprint
 
 metadata:
-  name: Blueprint-Skeleton-Generator
+  name: {{.BlueprintName}}
   description: |
     {{.Description}}
   author: XebiaLabs
@@ -46,7 +46,6 @@ spec:
 
   files:
   - path: xebialabs.yaml
-  - path: README.md
   - path: xebialabs/USAGE.md.tmpl
     writeIf: !expr "SomeCondition"
   - path: xebialabs/xld-apps.yaml.tmpl

--- a/blueprint-skeleton/xebialabs.yaml
+++ b/blueprint-skeleton/xebialabs.yaml
@@ -2,6 +2,7 @@ apiVersion: xl/v1
 kind: Import
 metadata:
   imports:
+  - xebialabs/xld-apps.yaml
   - xebialabs/xld-infra-env.yaml
   - xebialabs/xlr-pipeline-ci-cd.yaml
   - xebialabs/xlr-pipeline-destroy.yaml

--- a/blueprint-skeleton/xebialabs.yaml
+++ b/blueprint-skeleton/xebialabs.yaml
@@ -1,0 +1,7 @@
+apiVersion: xl/v1
+kind: Import
+metadata:
+  imports:
+  - xebialabs/xld-infra-env.yaml
+  - xebialabs/xlr-pipeline-ci-cd.yaml
+  - xebialabs/xlr-pipeline-destroy.yaml

--- a/blueprint-skeleton/xebialabs/xld-apps.yaml.tmpl.tmpl
+++ b/blueprint-skeleton/xebialabs/xld-apps.yaml.tmpl.tmpl
@@ -1,0 +1,23 @@
+{{"{{$app := .AppName | kebabcase}}"}}
+apiVersion: xl-deploy/v1
+kind: Applications
+spec:
+- name: {{"{{$app}}"}}
+  type: core.Directory
+  children:
+  - name: _NAME1_
+    type: udm.Application
+    children:
+    - name: '1.0.0'
+      type: udm.DeploymentPackage
+      deployables:
+      - name: _NAME_
+        type: _TYPE_
+  - name: _NAME2_
+    type: udm.Application
+    children:
+    - name: '1.0.0'
+      type: udm.DeploymentPackage
+      deployables:
+      - name: _NAME_
+      - type: _TYPE_

--- a/blueprint-skeleton/xebialabs/xld-infra-env.yaml.tmpl.tmpl
+++ b/blueprint-skeleton/xebialabs/xld-infra-env.yaml.tmpl.tmpl
@@ -1,0 +1,20 @@
+{{"{{$app := .AppName | kebabcase}}"}}
+apiVersion: xl-deploy/v1
+kind: Environments
+spec:
+- name: {{"{{$app}}"}}
+  type: core.Directory
+  children:
+  - name: _NAME2_
+    type: udm.Environment
+
+---
+
+apiVersion: xl-deploy/v1
+kind: Infrastructure
+spec:
+- name: {{"{{$app}}"}}
+  type: core.Directory
+  children:
+  - name: _NAME1_
+    type: _TYPE_

--- a/blueprint-skeleton/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl.tmpl
+++ b/blueprint-skeleton/xebialabs/xlr-pipeline-ci-cd.yaml.tmpl.tmpl
@@ -1,0 +1,59 @@
+{{"{{ $app := .AppName | kebabcase }}"}}
+apiVersion: xl-release/v1
+kind: Templates
+spec:
+- name: _FOLDER_NAME_
+  type: xlrelease.Folder
+  children:
+  - name: {{"{{$app}}-ci-cd"}}
+    type: xlrelease.Release
+    description: _DESCRIPTION_
+    tags:
+    - _TAG_
+    scriptUsername: !value XL_RELEASE_USERNAME
+    scriptUserPassword: !value XL_RELEASE_PASSWORD
+    variables:
+    - key: _NAME1_
+      type: xlrelease.StringVariable
+      requiresValue: true
+      showOnReleaseStart: true
+      value: _VALUE_
+    - key: _NAME2_
+      type: xlrelease.MapStringStringVariable
+      requiresValue: false
+      showOnReleaseStart: false
+      value:
+        _KEY1_: _VALUE1_
+        _KEY2_: _VALUE2_
+    - key: _NAME3_
+      type: xlrelease.PasswordStringVariable
+      requiresValue: true
+      showOnReleaseStart: false
+      value: !value XL_DEPLOY_PASSWORD
+    phases:
+    - name: Provision Infrastructure
+      type: xlrelease.Phase
+      color: '#d94c3d'
+      tasks:
+      - name: _TASK1_
+        type: xldeploy.Deploy
+        server: XL Deploy
+        deploymentPackage: ""
+        deploymentEnvironment: "Environments/_PATH_"
+    - name: Deploy Application
+      type: xlrelease.Phase
+      color: '#ff9e3b'
+      tasks:
+      - name: _TASK2_
+        type: xldeploy.Deploy
+        server: XL Deploy
+        deploymentPackage: ""
+        deploymentEnvironment: "Environments/_PATH_"
+      {{"{{ if .SomeCondition }}"}}
+      - name: _TASK3_
+        type: xldeploy.Deploy
+        server: XL Deploy
+        deploymentPackage: ""
+        deploymentEnvironment: "Environments/_PATH_"
+      {{"{{ end }}"}}
+

--- a/blueprint-skeleton/xebialabs/xlr-pipeline-destroy.yaml.tmpl.tmpl
+++ b/blueprint-skeleton/xebialabs/xlr-pipeline-destroy.yaml.tmpl.tmpl
@@ -1,0 +1,31 @@
+{{"{{ $app := .AppName | kebabcase }}"}}
+apiVersion: xl-release/v1
+kind: Templates
+spec:
+- name: _FOLDER_NAME_
+  type: xlrelease.Folder
+  children:
+  - name: {{"{{$app}}-destroy"}}
+    type: xlrelease.Release
+    description: _DESCRIPTION_
+    tags:
+    - _TAG_
+    scriptUsername: !value XL_RELEASE_USERNAME
+    scriptUserPassword: !value XL_RELEASE_PASSWORD
+    phases:
+    - name: Undeploy Application
+      type: xlrelease.Phase
+      color: '#d94c3d'
+      tasks:
+      - name: _TASK1_
+        type: xldeploy.Undeploy
+        server: XL Deploy
+        deployedApplication: "Environments/_PATH_"
+    - name: Deprovision Infrastructure
+      type: xlrelease.Phase
+      color: '#ff9e3b'
+      tasks:
+      - name: _TASK2_
+        type: xldeploy.Undeploy
+        server: XL Deploy
+        deployedApplication: "Environments/_PATH_"


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [x] The Travis CI for the PR is green
- [x] The blueprint has been reviewed by someone else in the team.
- [x] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [x] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [x] The blueprint works on Linux, Mac and Windows.
