### PR TITLE
LOVE-1116 Update AMI for aws/basic-eks-cluster

### DIFF
--- a/aws/basic-eks-cluster/blueprint.yaml
+++ b/aws/basic-eks-cluster/blueprint.yaml
@@ -186,7 +186,7 @@ spec:
   - path: cloudformation/eks-master.yaml
   - path: cloudformation/eks-user.yaml
   - path: cloudformation/eks-vpc.yaml
-  - path: cloudformation/eks-workers.yaml
+  - path: cloudformation/eks-workers.yaml.tmpl
   - path: cloudformation/efs.yaml
     writeIf: ProvisionEFS
   - path: xebialabs.yaml

--- a/aws/basic-eks-cluster/cloudformation/eks-workers.yaml.tmpl
+++ b/aws/basic-eks-cluster/cloudformation/eks-workers.yaml.tmpl
@@ -3,136 +3,116 @@ Description: 'Amazon EKS - Worker nodes'
 
 Mappings:
     RegionMap:
+        {{- if eq .ClusterVersion "1.10" }}
       us-east-2:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-0523ec257fff1261d"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-03c6648b74285020f"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-0fe61ae4c397e710d"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0485258c2d1c3608f"
-        {{- end }}
       us-east-1:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-01c1c96b9aa69de37"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-0a5f5d5b0f6f58199"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-0e380e0a62d368837"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0f2e8e5663e16b436"
-        {{- end }}
       us-west-2:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-021dd1fb7ba7e6e51"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-057d1c0dcb254a878"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-0355c210cb3f58aa2"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-03a55127c613349a7"
-        {{- end }}
       ap-south-1:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-04c2ed5ff15a580f4"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-00f1adebe5ab9a431"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-01b6a163133c31994"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0a9b1c1807b1a40ab"
-        {{- end }}
       ap-northeast-1:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-02ffa4511b4baa5fa"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-0a0b6606652f9b3b9"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-0a9b3f8b4b65b402b"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0fde798d17145fae1"
-        {{- end }}
       ap-northeast-2:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-06295f3e6390dae00"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-0c84b3f055cda1afb"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-069f6a654a8795f72"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-07fd7609df6c8e39b"
-        {{- end }}
       ap-southeast-1:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-07f8ccb046b3ce697"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-05e92412054db3f87"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-03737a1ac334a5767"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0361e14efd56a71c7"
-        {{- end }}
       ap-southeast-2:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": ami-03ebcd449b224e0a3
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": ami-07eb76498b1ba6cd6
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": ami-07580768e8538626f
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": ami-0237d87bc27daba65
-        {{- end }}
       eu-central-1:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-0c40973ffcf8bca40"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-0234bc9c2b341aa02"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-0ee5ca4231511cafc"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0b7127e7a2a38802a"
-        {{- end }}
       eu-west-1:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-06a96b4cfd627430b"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-06902949103360023"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-0404d23c7e8188740"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-00ac2e6b3cb38a9b9"
-        {{- end }}
       eu-west-2:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-03356e704fb004162"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-0db100ad46c7966d2"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-07346d8553f83f9d6"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0147919d2ff9a6ad5"
-        {{- end }}
       eu-west-3:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-0eb77a4ca7135122b"
-        {{- else if eq .ClusterVersion "1.11" }}
-        "AmiId": "ami-052046d313576d0ba"
-        {{- else if eq .ClusterVersion "1.12" }}
-        "AmiId": "ami-038cb36289174bac4"
-        {{- else if eq .ClusterVersion "1.13" }}
-        "AmiId": "ami-0537ee9329c1628a2"
-        {{- end }}
       eu-north-1:
-        {{- if eq .ClusterVersion "1.10" }}
         "AmiId": "ami-028df8ba9b8603bdd"
         {{- else if eq .ClusterVersion "1.11" }}
+      us-east-2:
+        "AmiId": "ami-03c6648b74285020f"
+      us-east-1:
+        "AmiId": "ami-0a5f5d5b0f6f58199"
+      us-west-2:
+        "AmiId": "ami-057d1c0dcb254a878"
+      ap-south-1:
+        "AmiId": "ami-00f1adebe5ab9a431"
+      ap-northeast-1:
+        "AmiId": "ami-0a0b6606652f9b3b9"
+      ap-northeast-2:
+        "AmiId": "ami-0c84b3f055cda1afb"
+      ap-southeast-1:
+        "AmiId": "ami-05e92412054db3f87"
+      ap-southeast-2:
+        "AmiId": ami-07eb76498b1ba6cd6
+      eu-central-1:
+        "AmiId": "ami-0234bc9c2b341aa02"
+      eu-west-1:
+        "AmiId": "ami-06902949103360023"
+      eu-west-2:
+        "AmiId": "ami-0db100ad46c7966d2"
+      eu-west-3:
+        "AmiId": "ami-052046d313576d0ba"
+      eu-north-1:
         "AmiId": "ami-02ebf24da505128f9"
         {{- else if eq .ClusterVersion "1.12" }}
+      us-east-2:
+        "AmiId": "ami-0fe61ae4c397e710d"
+      us-east-1:
+        "AmiId": "ami-0e380e0a62d368837"
+      us-west-2:
+        "AmiId": "ami-0355c210cb3f58aa2"
+      ap-south-1:
+        "AmiId": "ami-01b6a163133c31994"
+      ap-northeast-1:
+        "AmiId": "ami-0a9b3f8b4b65b402b"
+      ap-northeast-2:
+        "AmiId": "ami-069f6a654a8795f72"
+      ap-southeast-1:
+        "AmiId": "ami-03737a1ac334a5767"
+      ap-southeast-2:
+        "AmiId": ami-07580768e8538626f
+      eu-central-1:
+        "AmiId": "ami-0ee5ca4231511cafc"
+      eu-west-1:
+        "AmiId": "ami-0404d23c7e8188740"
+      eu-west-2:
+        "AmiId": "ami-07346d8553f83f9d6"
+      eu-west-3:
+        "AmiId": "ami-038cb36289174bac4"
+      eu-north-1:
         "AmiId": "ami-03e60b5a990893129"
         {{- else if eq .ClusterVersion "1.13" }}
+      us-east-2:
+        "AmiId": "ami-0485258c2d1c3608f"
+      us-east-1:
+        "AmiId": "ami-0f2e8e5663e16b436"
+      us-west-2:
+        "AmiId": "ami-03a55127c613349a7"
+      ap-south-1:
+        "AmiId": "ami-0a9b1c1807b1a40ab"
+      ap-northeast-1:
+        "AmiId": "ami-0fde798d17145fae1"
+      ap-northeast-2:
+        "AmiId": "ami-07fd7609df6c8e39b"
+      ap-southeast-1:
+        "AmiId": "ami-0361e14efd56a71c7"
+      ap-southeast-2:
+        "AmiId": ami-0237d87bc27daba65
+      eu-central-1:
+        "AmiId": "ami-0b7127e7a2a38802a"
+      eu-west-1:
+        "AmiId": "ami-00ac2e6b3cb38a9b9"
+      eu-west-2:
+        "AmiId": "ami-0147919d2ff9a6ad5"
+      eu-west-3:
+        "AmiId": "ami-0537ee9329c1628a2"
+      eu-north-1:
         "AmiId": "ami-0fd05922165907b85"
         {{- end }}
+
 
 Parameters:
   ProjectName:

--- a/aws/basic-eks-cluster/cloudformation/eks-workers.yaml.tmpl
+++ b/aws/basic-eks-cluster/cloudformation/eks-workers.yaml.tmpl
@@ -3,7 +3,7 @@ Description: 'Amazon EKS - Worker nodes'
 
 Mappings:
     RegionMap:
-        {{- if eq .ClusterVersion "1.10" }}
+    {{- if eq .ClusterVersion "1.10" }}
       us-east-2:
         "AmiId": "ami-0523ec257fff1261d"
       us-east-1:
@@ -19,7 +19,7 @@ Mappings:
       ap-southeast-1:
         "AmiId": "ami-07f8ccb046b3ce697"
       ap-southeast-2:
-        "AmiId": ami-03ebcd449b224e0a3
+        "AmiId": "ami-03ebcd449b224e0a3"
       eu-central-1:
         "AmiId": "ami-0c40973ffcf8bca40"
       eu-west-1:
@@ -30,7 +30,7 @@ Mappings:
         "AmiId": "ami-0eb77a4ca7135122b"
       eu-north-1:
         "AmiId": "ami-028df8ba9b8603bdd"
-        {{- else if eq .ClusterVersion "1.11" }}
+    {{- else if eq .ClusterVersion "1.11" }}
       us-east-2:
         "AmiId": "ami-03c6648b74285020f"
       us-east-1:
@@ -46,7 +46,7 @@ Mappings:
       ap-southeast-1:
         "AmiId": "ami-05e92412054db3f87"
       ap-southeast-2:
-        "AmiId": ami-07eb76498b1ba6cd6
+        "AmiId": "ami-07eb76498b1ba6cd6"
       eu-central-1:
         "AmiId": "ami-0234bc9c2b341aa02"
       eu-west-1:
@@ -57,7 +57,7 @@ Mappings:
         "AmiId": "ami-052046d313576d0ba"
       eu-north-1:
         "AmiId": "ami-02ebf24da505128f9"
-        {{- else if eq .ClusterVersion "1.12" }}
+    {{- else if eq .ClusterVersion "1.12" }}
       us-east-2:
         "AmiId": "ami-0fe61ae4c397e710d"
       us-east-1:
@@ -73,7 +73,7 @@ Mappings:
       ap-southeast-1:
         "AmiId": "ami-03737a1ac334a5767"
       ap-southeast-2:
-        "AmiId": ami-07580768e8538626f
+        "AmiId": "ami-07580768e8538626f"
       eu-central-1:
         "AmiId": "ami-0ee5ca4231511cafc"
       eu-west-1:
@@ -84,7 +84,7 @@ Mappings:
         "AmiId": "ami-038cb36289174bac4"
       eu-north-1:
         "AmiId": "ami-03e60b5a990893129"
-        {{- else if eq .ClusterVersion "1.13" }}
+    {{- else if eq .ClusterVersion "1.13" }}
       us-east-2:
         "AmiId": "ami-0485258c2d1c3608f"
       us-east-1:
@@ -100,7 +100,7 @@ Mappings:
       ap-southeast-1:
         "AmiId": "ami-0361e14efd56a71c7"
       ap-southeast-2:
-        "AmiId": ami-0237d87bc27daba65
+        "AmiId": "ami-0237d87bc27daba65"
       eu-central-1:
         "AmiId": "ami-0b7127e7a2a38802a"
       eu-west-1:
@@ -111,7 +111,7 @@ Mappings:
         "AmiId": "ami-0537ee9329c1628a2"
       eu-north-1:
         "AmiId": "ami-0fd05922165907b85"
-        {{- end }}
+    {{- end }}
 
 
 Parameters:

--- a/aws/basic-eks-cluster/cloudformation/eks-workers.yaml.tmpl
+++ b/aws/basic-eks-cluster/cloudformation/eks-workers.yaml.tmpl
@@ -3,32 +3,136 @@ Description: 'Amazon EKS - Worker nodes'
 
 Mappings:
     RegionMap:
-        us-west-2:
-            "AmiId": "ami-05a71d034119ffc12"
-        us-east-1:
-            "AmiId": "ami-03a1e71fb42fc37dd"
-        us-east-2:
-            "AmiId": "ami-093d55c2ba99ab2c8"
-        eu-central-1:
-            "AmiId": "ami-03bdf8079f6c013c5"
-        eu-north-1:
-            "AmiId": "ami-0be77fe86d741fc81"
-        eu-west-1:
-            "AmiId": "ami-06368da7f495b68e9"
-        eu-west-2:
-            "AmiId": "ami-0f1f2189b4741bc60"
-        eu-west-3:
-            "AmiId": "ami-03a9acb0f6e0d424d"
-        ap-northeast-1:
-            "AmiId": "ami-0c9fb6a3fda95d373"
-        ap-northeast-2:
-            "AmiId": "ami-00ea4ea959f28b4cf"
-        ap-south-1:
-            "AmiId": "ami-0f07478f5c5eb9e20"
-        ap-southeast-1:
-            "AmiId": "ami-05dac5d0ada75e22f"
-        ap-southeast-2:
-            "AmiId": "ami-00513f18e1900ce1e"
+      us-east-2:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-0523ec257fff1261d"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-03c6648b74285020f"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-0fe61ae4c397e710d"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0485258c2d1c3608f"
+        {{- end }}
+      us-east-1:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-01c1c96b9aa69de37"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-0a5f5d5b0f6f58199"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-0e380e0a62d368837"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0f2e8e5663e16b436"
+        {{- end }}
+      us-west-2:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-021dd1fb7ba7e6e51"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-057d1c0dcb254a878"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-0355c210cb3f58aa2"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-03a55127c613349a7"
+        {{- end }}
+      ap-south-1:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-04c2ed5ff15a580f4"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-00f1adebe5ab9a431"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-01b6a163133c31994"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0a9b1c1807b1a40ab"
+        {{- end }}
+      ap-northeast-1:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-02ffa4511b4baa5fa"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-0a0b6606652f9b3b9"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-0a9b3f8b4b65b402b"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0fde798d17145fae1"
+        {{- end }}
+      ap-northeast-2:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-06295f3e6390dae00"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-0c84b3f055cda1afb"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-069f6a654a8795f72"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-07fd7609df6c8e39b"
+        {{- end }}
+      ap-southeast-1:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-07f8ccb046b3ce697"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-05e92412054db3f87"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-03737a1ac334a5767"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0361e14efd56a71c7"
+        {{- end }}
+      ap-southeast-2:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": ami-03ebcd449b224e0a3
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": ami-07eb76498b1ba6cd6
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": ami-07580768e8538626f
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": ami-0237d87bc27daba65
+        {{- end }}
+      eu-central-1:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-0c40973ffcf8bca40"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-0234bc9c2b341aa02"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-0ee5ca4231511cafc"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0b7127e7a2a38802a"
+        {{- end }}
+      eu-west-1:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-06a96b4cfd627430b"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-06902949103360023"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-0404d23c7e8188740"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-00ac2e6b3cb38a9b9"
+        {{- end }}
+      eu-west-2:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-03356e704fb004162"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-0db100ad46c7966d2"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-07346d8553f83f9d6"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0147919d2ff9a6ad5"
+        {{- end }}
+      eu-west-3:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-0eb77a4ca7135122b"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-052046d313576d0ba"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-038cb36289174bac4"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0537ee9329c1628a2"
+        {{- end }}
+      eu-north-1:
+        {{- if eq .ClusterVersion "1.10" }}
+        "AmiId": "ami-028df8ba9b8603bdd"
+        {{- else if eq .ClusterVersion "1.11" }}
+        "AmiId": "ami-02ebf24da505128f9"
+        {{- else if eq .ClusterVersion "1.12" }}
+        "AmiId": "ami-03e60b5a990893129"
+        {{- else if eq .ClusterVersion "1.13" }}
+        "AmiId": "ami-0fd05922165907b85"
+        {{- end }}
 
 Parameters:
   ProjectName:


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [x] The blueprint applies to a focused use case.
- [x] The blueprint uses at least one XebiaLabs product.
- [x] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [x] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [x] The branch from which the PR is created is up-to-date with the `development` branch.
- [x] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [x] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [x] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [x] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [x] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [x] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [x] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [x] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [x] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [x] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [x] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [x] The blueprint works on Linux, Mac and Windows.
