### PR TITLE
LOVE-1232 Remove Jetpack option from blueprints

### DIFF
--- a/.github/BLUEPRINT_README_TEMPLATE.md
+++ b/.github/BLUEPRINT_README_TEMPLATE.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/basic-eks-cluster/README.md
+++ b/aws/basic-eks-cluster/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/basic-eks-cluster/blueprint.yaml
+++ b/aws/basic-eks-cluster/blueprint.yaml
@@ -161,8 +161,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/aws/basic-lambda/README.md
+++ b/aws/basic-lambda/README.md
@@ -13,7 +13,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/basic-lambda/blueprint.yaml
+++ b/aws/basic-lambda/blueprint.yaml
@@ -54,8 +54,6 @@ spec:
       value: 4516
     - name: UseXLRelease
       value: false
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/aws/datalake/README.md
+++ b/aws/datalake/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/datalake/blueprint.yaml
+++ b/aws/datalake/blueprint.yaml
@@ -94,8 +94,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/aws/elastic-beanstalk/README.md
+++ b/aws/elastic-beanstalk/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/elastic-beanstalk/blueprint.yaml
+++ b/aws/elastic-beanstalk/blueprint.yaml
@@ -78,8 +78,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/aws/intermediate-eks-cluster/README.md
+++ b/aws/intermediate-eks-cluster/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/intermediate-eks-cluster/blueprint.yaml
+++ b/aws/intermediate-eks-cluster/blueprint.yaml
@@ -174,8 +174,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/aws/microservice-ecommerce/README.md
+++ b/aws/microservice-ecommerce/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/microservice-ecommerce/blueprint.yaml
+++ b/aws/microservice-ecommerce/blueprint.yaml
@@ -104,8 +104,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/aws/monolith-terraform/README.md
+++ b/aws/monolith-terraform/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 
@@ -71,7 +70,7 @@ This blueprint will output:
     * Security infrastructure
     * Elastic Load Balancer (ELB) infrastructure
     * Amazon Relational Database Service (RDS)
-* A docker-compose setup for XL JetPack
+* A docker-compose setup for XL
 
 ## Tips and tricks
 

--- a/aws/monolith-terraform/README.md
+++ b/aws/monolith-terraform/README.md
@@ -70,7 +70,7 @@ This blueprint will output:
     * Security infrastructure
     * Elastic Load Balancer (ELB) infrastructure
     * Amazon Relational Database Service (RDS)
-* A docker-compose setup for XL Products
+* A docker-compose setup for XL Release and XL Deploy
 
 ## Tips and tricks
 

--- a/aws/monolith-terraform/README.md
+++ b/aws/monolith-terraform/README.md
@@ -70,7 +70,7 @@ This blueprint will output:
     * Security infrastructure
     * Elastic Load Balancer (ELB) infrastructure
     * Amazon Relational Database Service (RDS)
-* A docker-compose setup for XL
+* A docker-compose setup for XL Products
 
 ## Tips and tricks
 

--- a/aws/monolith-terraform/blueprint.yaml
+++ b/aws/monolith-terraform/blueprint.yaml
@@ -62,8 +62,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "JetPack"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/aws/monolith/README.md
+++ b/aws/monolith/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/aws/monolith/blueprint.yaml
+++ b/aws/monolith/blueprint.yaml
@@ -62,8 +62,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/azure/app-service-docker-app/README.md
+++ b/azure/app-service-docker-app/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/azure/app-service-docker-app/blueprint.yaml
+++ b/azure/app-service-docker-app/blueprint.yaml
@@ -151,8 +151,6 @@ spec:
       value: 4516
     - name: UseXLRelease
       value: false
-    - name: JetPackOrEnterprise
-      value: "JetPack"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/azure/basic-aks-cluster/README.md
+++ b/azure/basic-aks-cluster/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/azure/basic-aks-cluster/blueprint.yaml
+++ b/azure/basic-aks-cluster/blueprint.yaml
@@ -125,8 +125,6 @@ spec:
       value: 4516
     - name: UseXLRelease
       value: false
-    - name: JetPackOrEnterprise
-      value: "JetPack"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/azure/microservice-ecommerce/README.md
+++ b/azure/microservice-ecommerce/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Tools and technologies
 
@@ -284,7 +283,7 @@ The blueprint will output:
 * Infrastructure:
     * AKS cluster (master, nodes)
     * Security infrastructure
-* A docker-compose setup for XL JetPack and Jenkins
+* A docker-compose setup for XL and Jenkins
 
 **Note:** You will find more instructions in `xebialabs/USAGE.md` after you have run the blueprint.
 

--- a/azure/microservice-ecommerce/README.md
+++ b/azure/microservice-ecommerce/README.md
@@ -283,7 +283,7 @@ The blueprint will output:
 * Infrastructure:
     * AKS cluster (master, nodes)
     * Security infrastructure
-* A docker-compose setup for XL and Jenkins
+* A docker-compose setup for XL Release, XL Deploy and Jenkins
 
 **Note:** You will find more instructions in `xebialabs/USAGE.md` after you have run the blueprint.
 

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -202,8 +202,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "JetPack"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/blueprint-skeleton/README.md.tmpl
+++ b/blueprint-skeleton/README.md.tmpl
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/devsecops/security-scanning/README.md
+++ b/devsecops/security-scanning/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/devsecops/security-scanning/blueprint.yaml
+++ b/devsecops/security-scanning/blueprint.yaml
@@ -148,8 +148,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/docker/application/README.md
+++ b/docker/application/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/docker/composable-demo/README.md
+++ b/docker/composable-demo/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/docker/composable-demo/__test__/answers.yaml
+++ b/docker/composable-demo/__test__/answers.yaml
@@ -3,7 +3,6 @@ DockerImageRepository: nginx
 DockerImageTag: latest
 ExposePort: false
 XLDeployPort: 4321
-JetPackOrEnterprise: JetPack
 XLVersion: 8.6.1
 UseDockerProxy: true
 GenerateDockerComposeSetup: true

--- a/docker/composable-demo/blueprint.yaml
+++ b/docker/composable-demo/blueprint.yaml
@@ -31,8 +31,6 @@ spec:
       value: 4516
     - name: UseXLRelease
       value: false
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/docker/environment/README.md
+++ b/docker/environment/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/docker/simple-demo-app/README.md
+++ b/docker/simple-demo-app/README.md
@@ -10,7 +10,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/docker/simple-demo-app/blueprint.yaml
+++ b/docker/simple-demo-app/blueprint.yaml
@@ -49,8 +49,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/gcp/basic-gke-cluster/README.md
+++ b/gcp/basic-gke-cluster/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 

--- a/gcp/basic-gke-cluster/blueprint.yaml
+++ b/gcp/basic-gke-cluster/blueprint.yaml
@@ -117,8 +117,6 @@ spec:
       value: 4516
     - name: UseXLRelease
       value: false
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/gcp/microservice-ecommerce/README.md
+++ b/gcp/microservice-ecommerce/README.md
@@ -121,7 +121,7 @@ This blueprint will output:
     * GKE cluster (master, nodes)
     * Networking infrastructure: Virtual Private Cloud (VPC), subnets
     * Security infrastructure
-* A docker-compose setup for XL and Jenkins
+* A docker-compose setup for XL Release, XL Deploy and Jenkins
 
 ## Tips and tricks
 

--- a/gcp/microservice-ecommerce/README.md
+++ b/gcp/microservice-ecommerce/README.md
@@ -12,7 +12,6 @@ If you're new to XebiaLabs blueprints, check out:
 
 * [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
 * [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
-* [Get started with XL JetPack](https://docs.xebialabs.com/xl-platform/concept/get-started-with-xl-jetpack.html)
 
 ## Usage
 
@@ -122,7 +121,7 @@ This blueprint will output:
     * GKE cluster (master, nodes)
     * Networking infrastructure: Virtual Private Cloud (VPC), subnets
     * Security infrastructure
-* A docker-compose setup for XL JetPack and Jenkins
+* A docker-compose setup for XL and Jenkins
 
 ## Tips and tricks
 

--- a/gcp/microservice-ecommerce/blueprint.yaml
+++ b/gcp/microservice-ecommerce/blueprint.yaml
@@ -111,8 +111,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/kubernetes/multicloud-pipeline/blueprint.yaml
+++ b/kubernetes/multicloud-pipeline/blueprint.yaml
@@ -97,8 +97,6 @@ spec:
       value: true
     - name: XLReleasePort
       value: 5516
-    - name: JetPackOrEnterprise
-      value: "XL Enterprise"
     - name: XLVersion
       value: "9.0"
     - name: UseDockerProxy

--- a/xl-devops-platform/__test__/answers-with-xl-release.yaml
+++ b/xl-devops-platform/__test__/answers-with-xl-release.yaml
@@ -2,7 +2,6 @@ UseXLDeploy: true
 XLDeployPort: 4516
 UseXLRelease: true
 XLReleasePort: 4516
-JetPackOrEnterprise: JetPack
-XLVersion: 8.6.1
+XLVersion: "9.0"
 UseDockerProxy: true
 UseJenkins: false

--- a/xl-devops-platform/__test__/answers-without-xl-release-jenkins.yaml
+++ b/xl-devops-platform/__test__/answers-without-xl-release-jenkins.yaml
@@ -2,7 +2,6 @@ UseXLDeploy: true
 XLDeployPort: 4516
 UseXLRelease: false
 XLReleasePort: 4516
-JetPackOrEnterprise: JetPack
-XLVersion: 8.6.1
+XLVersion: "9.0"
 UseDockerProxy: true
 UseJenkins: false

--- a/xl-devops-platform/__test__/answers-without-xl-release.yaml
+++ b/xl-devops-platform/__test__/answers-without-xl-release.yaml
@@ -2,8 +2,7 @@ UseXLDeploy: true
 XLDeployPort: 4516
 UseXLRelease: false
 XLReleasePort: 4516
-JetPackOrEnterprise: JetPack
-XLVersion: 8.6.1
+XLVersion: "9.0"
 UseDockerProxy: true
 UseJenkins: true
 JenkinsPort: 8080

--- a/xl-devops-platform/blueprint.yaml
+++ b/xl-devops-platform/blueprint.yaml
@@ -32,13 +32,6 @@ spec:
     promptIf: UseXLRelease
     default: 5516
 
-  - name: JetPackOrEnterprise
-    type: Select
-    prompt: "Do you want to use JetPack or XL Enterprise:"
-    options:
-      - JetPack
-      - XL Enterprise
-
   - name: XLVersion
     type: Select
     prompt: "Select the version of XL you want to use:"

--- a/xl-devops-platform/docker/docker-compose.yml.tmpl
+++ b/xl-devops-platform/docker/docker-compose.yml.tmpl
@@ -2,11 +2,7 @@ version: '3.7'
 services:
   {{- if .UseXLDeploy }}
   xl-deploy:
-    {{- if eq .JetPackOrEnterprise "JetPack" }}
-    image: xebialabs/xl-jetpack-deploy:{{ .XLVersion }}
-    {{- else }}
     image: xebialabs/xl-deploy:{{ .XLVersion }}
-    {{- end }}
     ports:
     - "{{.XLDeployPort}}:4516"
     environment:
@@ -16,11 +12,7 @@ services:
 
   {{- if .UseXLRelease }}
   xl-release:
-    {{- if eq .JetPackOrEnterprise "JetPack" }}
-    image: xebialabs/xl-jetpack-release:{{ .XLVersion }}
-    {{- else }}
     image: xebialabs/xl-release:{{ .XLVersion }}
-    {{- end }}
     ports:
     - "{{.XLReleasePort}}:5516"
     environment:


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
