### PR TITLE
Small skeleton fixes

### DIFF
--- a/blueprint-skeleton/README.md.tmpl
+++ b/blueprint-skeleton/README.md.tmpl
@@ -8,8 +8,8 @@
 
 If you're new to XebiaLabs blueprints, check out:
 
-* [Get started with DevOps as Code](https://docs.xebialabs.com/xl-platform/concept/get-started-with-devops-as-code.html)
-* [Get started with blueprints](https://docs.xebialabs.com/xl-platform/concept/get-started-with-blueprints.html)
+* [Get started with DevOps as Code](https://docs.xebialabs.com/xl-release/concept/get-started-with-devops-as-code.html)
+* [Get started with blueprints](https://docs.xebialabs.com/xl-release/concept/get-started-with-blueprints.html)
 
 ## Usage
 

--- a/blueprint-skeleton/USAGE-skeleton.md.tmpl
+++ b/blueprint-skeleton/USAGE-skeleton.md.tmpl
@@ -7,7 +7,7 @@ Now that you've created your blueprint skeleton, there are a few more steps:
 3. When you're done reading this file, delete it, as it should not be part of your blueprint
 
 The files in this skeleton make up a basic blueprint with the most common elements. For more detail, refer to the online documentation:
-* [Blueprint YAML format](https://docs.xebialabs.com/xl-platform/concept/blueprint-yaml-format.html)
+* [Blueprint YAML format](https://docs.xebialabs.com/xl-deploy/concept/blueprint-yaml-format/)
 * [Go Templates](https://golang.org/pkg/text/template/)
 * [Using Go Templates](https://blog.gopheracademy.com/advent-2017/using-go-templates/)
 

--- a/blueprint-skeleton/__test__/test.yaml.tmpl
+++ b/blueprint-skeleton/__test__/test.yaml.tmpl
@@ -1,7 +1,6 @@
 answers-file: answers.yaml
 expected-files:
 - xebialabs.yaml
-- README.md
 - xebialabs/USAGE.md
 - xebialabs/xld-apps.yaml
 - xebialabs/xld-infra-env.yaml


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
