### PR TITLE
LOVE-1375 Deduplicate GenerateDockerComposeSetup

### DIFF
--- a/showcases/dictionaries-and-secret-stores/blueprint.yaml
+++ b/showcases/dictionaries-and-secret-stores/blueprint.yaml
@@ -117,6 +117,10 @@ spec:
     - label: "Med security - encrypted dictionary to be created within XL Deploy"
       value: dictionary
 
+  - name: GenerateDockerComposeSetup
+    type: Confirm
+    prompt: "Do you want to generate a docker-compose setup with the required tools to run this blueprint?"
+    default: false
   includeAfter:
   - blueprint: fragments/secret-store
     includeIf: !expr "CredentialsSource == 'secret-store'"

--- a/xl-devops-platform/blueprint.yaml
+++ b/xl-devops-platform/blueprint.yaml
@@ -10,38 +10,34 @@ metadata:
 
 spec:
   parameters:
-  - name: GenerateDockerComposeSetup
-    type: Confirm
-    prompt: "Do you want to generate a docker-compose setup with the required tools to run this blueprint?"
 
   - name: UseXLDeploy
     type: Confirm
     prompt: Do you want to install XL Deploy?
-    promptIf: GenerateDockerComposeSetup
     default: true
 
   - name: XLDeployPort
     type: Input
     prompt: "Host port for XL Deploy:"
-    promptIf: !expr "GenerateDockerComposeSetup && UseXLDeploy"
+    promptIf: !expr "UseXLDeploy"
     default: 4516
 
   - name: UseXLRelease
     type: Confirm
     prompt: Do you want to install XL Release?
-    promptIf: GenerateDockerComposeSetup
     default: true
 
   - name: XLReleasePort
     type: Input
     prompt: "Host port for XL Release:"
-    promptIf: !expr "GenerateDockerComposeSetup && UseXLRelease"
+    promptIf: !expr "UseXLRelease"
     default: 5516
 
   - name: XLVersion
     type: Select
     prompt: "Select the version of XL you want to use:"
-    promptIf: !expr "GenerateDockerComposeSetup && (UseXLDeploy == true || UseXLRelease == true)"
+    promptIf: !expr "UseXLDeploy == true || UseXLRelease == true"
+    default: "9.0"
     options:
       - "9.0"
       - "8.6.1"
@@ -49,13 +45,12 @@ spec:
   - name: UseJenkins
     type: Confirm
     prompt: Do you want to be able to run CI using a pre-configured Jenkins instance?
-    promptIf: GenerateDockerComposeSetup
     default: false
 
   - name: JenkinsPort
     type: Input
     prompt: "Host port for Jenkins:"
-    promptIf: !expr "GenerateDockerComposeSetup && UseJenkins"
+    promptIf: !expr "UseJenkins"
     default: 8080
 
   - name: JenkinsBranch
@@ -64,18 +59,16 @@ spec:
   - name: UseDockerProxy
     type: Confirm
     prompt: Do you want to be able to deploy to your local Docker instance using Docker proxy?
-    promptIf: GenerateDockerComposeSetup
     description: This is meant for development purposes and hence is not a best practice that should be used in production
     default: false
 
   files:
+  # XebiaLabs
   - path: xebialabs/USAGE-docker-compose.md.tmpl
-    writeIf: GenerateDockerComposeSetup
   - path: xebialabs/config.yaml.tmpl
-    writeIf: GenerateDockerComposeSetup
+  # Docker
   - path: docker/docker-compose.yml.tmpl
-    writeIf: GenerateDockerComposeSetup
   - path: docker/data/configure-xl-devops-platform.yaml.tmpl
-    writeIf: !expr "GenerateDockerComposeSetup && (UseXLRelease || UseJenkins)"
+    writeIf: !expr "UseXLRelease || UseJenkins"
   - path: docker/jenkins/jenkins.yaml.tmpl
-    writeIf: !expr "GenerateDockerComposeSetup && UseJenkins"
+    writeIf: !expr "UseJenkins"


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
