### PR TITLE
LOVE-1336 Add common documentation for Azure, AWS, GCP, Docker, Kubernetes

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,17 @@
+# Amazon Web Services
+
+These are notes common to all AWS blueprints.
+
+## AWS CLI
+
+If you want the blueprint to automatically detect your AWS Access Key and AWS Secret Access Key, you'll need to install and configure the CLI.
+
+### Install the CLI
+
+1. Follow [these instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) for your platform or use your platform's package manager to install the CLI.
+
+2. Make sure the `aws` binary is on your classpath.
+
+3. Run `aws configure` and follow the prompts.
+
+You should now be set up to use the AWS CLI and have the blueprints detect the AWS secrets.

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,0 +1,202 @@
+# Microsoft Azure
+
+These are notes common to all AWS blueprints.
+
+All the Azure blueprints require the following information:
+
+* Azure credentials
+  * Client ID
+  * Client secret (password)
+  * Subscription ID
+  * Tenant ID
+* Resource group
+* Geographic Location
+
+## Azure CLI
+
+The Azure CLI is not strictly necessary for running the blueprints, but is very useful for obtaining the credentials and creating certain resources.
+
+### Install the CLI
+
+Follow [these instructions](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) to install the Azure CLI on your platform.
+
+### Log in
+
+Run the following command to log in:
+
+```plain
+az login
+```
+
+Follow the prompts to complete the authentication.
+
+> **Note:** You need to have the proper permissions and privileges in your Azure account to execute these commands. If you are using a personal account you should be having these as you will be the admin. If you are using a company/enterprise account please check with your account administrator.
+
+## Create a Service Principal and obtain the Azure credentials to be used in the blueprints
+
+When you run a blueprint, it may prompt you for the following four Azure properties:
+
+1. `client id`
+2. `client secret`
+3. `subscription id`
+4. `tenant id`
+
+> **Note:** If you are familiar with Azure, you may already have these values or know how to find them. If not, or if you are new to Azure, the following steps will explain how to create the necessary accounts/objects to obtain these values.
+
+**See:**
+
+* [Application and service principal objects in Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals)
+
+### Obtain the `subscription id` and `tenant id`
+
+Run the following command to see the list of subscriptions you can access:
+
+```plain
+az account list
+```
+
+This will output something like:
+
+```json
+[
+  {
+    "cloudName": "AzureCloud",
+    "id": "5dses33-f595-3333-6666-77788889997",
+    "isDefault": true,
+    "name": "Free Trial",
+    "state": "Enabled",
+    "tenantId": "7f3c634b-3ds4-23fe-8aa7-dme3jdwejqdxv",
+    "user": {
+      "name": "user@email.com",
+      "type": "user"
+    }
+  }
+]
+```
+
+In this output:
+
+* `id` is the `subscription_id` for the blueprints
+* `tenantId` is the `tenant_id` for the blueprints
+
+Note these down and substitute `SUBSCRIPTION_ID` in the following steps where you will create a functional user that has privileges to spin up a managed K8s cluster.
+
+### Create the Service Principal and obtain the `client id` and `client secret`
+
+Run the following command to create the Service Principal:
+
+```plain
+az ad sp create-for-rbac --role="Contributor"
+                         --name YOURNAME
+                         --scopes="/subscriptions/SUBSCRIPTION_ID"
+```
+
+This will output something like:
+
+```json
+{
+  "appId": "99999-0000-8888-7777-888877776755",
+  "displayName": "azure-cli-2019-04-19-17-32-40",
+  "name": "http://azure-cli-2019-04-19-17-32-40",
+  "password": "77778888-7788-9998-92fc-huoui89889",
+  "tenant": "7f3c634b-3ds4-23fe-8aa7-dme3jdwejqdxv"
+}
+```
+
+In this output:
+
+* `appId` is the `client_id` for the blueprints
+* `password` is the `client_secret` for the blueprints
+
+Note these down. You now have all four values to run Azure blueprints.
+
+**See:**
+
+* [Create an Azure service principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest)
+
+
+## Set up Terraform's backend storage for creating a Kubernetes cluster
+
+In this step, you will create the necessary storage objects so that Terraform can store its internal state with Azure and keep track of the cluster it will build.
+
+> **Note:** These step are only necessary if:
+>
+> * The blueprint needs a Kubernetes cluster
+> * You want the blueprint to create a new cluster for you
+
+### Create a Resource Group to house the storage
+
+> **Note:** While each blueprint prompts you for a Resource Group to house its resources, you will need a separate Resource Group for storage.
+
+Run the following command to create the Resource Group:
+
+```plain
+az group create --name RESOURCE_GROUP
+                --location LOCATION
+```
+
+**See:**
+
+* [Create a resource group](https://docs.microsoft.com/en-us/cli/azure/group?view=azure-cli-latest#az-group-create)
+
+### Create a Storage Account
+
+Run:
+
+```plain
+az storage account create --name STORAGE_ACCOUNT_NAME \
+                          --resource-group RESOURCE_GROUP \
+                          --location LOCATION \
+                          --sku Standard_LRS
+```
+
+**See:**
+
+* [Create a storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=azure-cli)
+
+### Obtain a key in order to create a Storage Container
+
+Run:
+
+```plain
+az storage account keys list --account-name STORAGE_ACCOUNT_NAME
+```
+
+This will output something like:
+
+```json
+[
+  {
+    "keyName": "key1",
+    "permissions": "Full",
+    "value": "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmn=="
+  },
+  {
+    "keyName": "key2",
+    "permissions": "Full",
+    "value": "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmn=="
+  }
+]
+```
+
+Note one of the account keys down for use in the next step and in the blueprint.
+
+**See:**
+
+* [Storage account keys](https://docs.microsoft.com/en-us/cli/azure/storage/account/keys?view=azure-cli-latest)
+
+### Create a Storage Container
+
+> **Note:** For this step, name the container `terraform-state`, as this is also the default in the blueprint. If you want to give it a different name, remember to use that name when prompted by the blueprint.
+
+Run:
+
+```plain
+az storage container create --name terraform-state
+                            --account-key ACCOUNT_KEY
+                            --account-name STORAGE_ACCOUNT_NAME
+```
+
+**See:**
+
+* [Create a storage container](https://docs.microsoft.com/en-us/cli/azure/storage/container?view=azure-cli-latest#az-storage-container-create)

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -142,17 +142,17 @@ spec:
 
   - name: StorageAccountName
     type: Input
-    prompt: "Enter the Storage Account where Terraform will store its state (see README.md step 3.2):"
+    prompt: "Enter the Storage Account where Terraform will store its state (see aws/README.md):"
     promptIf: ProvisionCluster
 
   - name: StorageAccessKey
     type: Input
-    prompt: "Enter the Storage Account key for accessing the storage (see README.md step 3.3):"
+    prompt: "Enter the Storage Account key for accessing the storage (see aws/README.md):"
     promptIf: ProvisionCluster
 
   - name: StorageContainerName
     type: Input
-    prompt: "Enter the Storage Container name (see README.md step 3.4):"
+    prompt: "Enter the Storage Container name (see aws/README.md):"
     promptIf: ProvisionCluster
     default: terraform-state
   # ############################################################################

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,16 @@
+# Docker
+
+These are notes common to all Docker blueprints.
+
+## Docker proxy
+
+If you are using a platform other than Linux, you'll need to deploy a Docker proxy (on port 2375) so that XL Deploy will be able to deploy Docker images.
+
+You can deploy the proxy by:
+
+1. Running the `xl-devops-platform` blueprint separately
+2. Running the `xl-devops-platform` blueprint as part of one of the Docker blueprints
+
+### Linux
+
+Under Linux, follow [these instructions](https://docs.docker.com/engine/reference/commandline/dockerd/) for setting up TCP access to port 2375.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -1,0 +1,76 @@
+# Google Cloud Platform
+
+These are notes common to all GCP blueprints.
+
+## Google Cloud SDK
+
+### Install the CLI
+
+Follow [these instructions](https://cloud.google.com/sdk/install) to install the Google Cloud Platform SDK on your platform.
+
+### Log in
+
+Run the following command to log in:
+
+```plain
+gcloud auth login
+```
+
+Follow the prompts to complete the authentication.
+
+## Create a Google Cloud project
+
+Create a new project and link it to your billing account (You could do it from the GCP console GUI as well, in that case skip the below command)
+
+> **Note:** First, retrieve the values of YOUR_ORG_ID and YOUR_BILLING_ACCOUNT_ID by executing the following commands:
+
+```plain
+gcloud organizations list
+
+gcloud beta billing accounts list
+```
+
+Once you have the details run the following commands:
+
+```plain
+gcloud projects create [PROJECT_NAME] \
+--organization [YOUR_ORG_ID] \
+
+gcloud beta billing projects link [PROJECT_NAME] \
+--billing-account [YOUR_BILLING_ACCOUNT_ID]
+```
+
+> **Note:** If you are not the admin of a GCP account, ask your administrator to create and link the project for you.
+
+
+### Set the project
+
+Run the following command to set your project:
+
+```plain
+gcloud config set project PROJECT_NAME
+```
+
+### Initiate gcloud
+
+Before running the `gcloud init` command, check for available zones and regions nearest to your location by running:
+
+```plain
+gcloud compute regions list
+
+gcloud compute zones list
+```
+
+Run the following command and select a default zone (e.g. `europe-west1`). Make sure you use the same zone as the one you intend to use with blueprints.
+
+```plain
+gcloud init
+```
+
+### `TF_ADMIN` for Terraform
+
+> **Note:** If you are creating the project using the GUI instead of the commands below, there will be a project number, a project name and a project ID when you initialize the project, and only ID should be exported as `TF_ADMIN` variable.
+
+```plain
+export TF_ADMIN=[GCP project ID]
+```


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
