### PR TITLE
LOVE-1399 Fixes for azure/microservice-ecommerce

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -1,6 +1,6 @@
 # Microsoft Azure
 
-These are notes common to all AWS blueprints.
+These are notes common to all Azure blueprints.
 
 All the Azure blueprints require the following information:
 

--- a/azure/microservice-ecommerce/README.md
+++ b/azure/microservice-ecommerce/README.md
@@ -23,8 +23,13 @@ If you're new to XebiaLabs blueprints, check out:
 
 1. Fork the https://github.com/xebialabs/e-commerce-microservice repository
 2. Clone your fork of the repository
+3. Check out the `gke-blueprint` branch:
+    ```plain
+    git co -b gke-blueprint origin/gke-blueprint
+    ```
 
 > For more detailed instructions, see [Deploy an app to AWS using a blueprint](https://docs.xebialabs.com/v.9.0/xl-release/how-to/deploy-to-aws-using-blueprints)
+> **Note:** This blueprint uses the same branch as the Google GKE example
 
 ## Usage
 
@@ -63,7 +68,7 @@ This blueprint version requires at least the following versions of the specified
 * Azure Resource Group
 * Azure Region
 * The AKS cluster endpoint, if you are deploying to an existing cluster
-* Azure Storage Account for the Terraform state, if creating a new cluster (see step 3.2)
+* Azure Storage Account for the Terraform state, if creating a new cluster
 * Kubernetes cluster credentials
 * The Kubernetes namespace
 

--- a/azure/microservice-ecommerce/blueprint.yaml
+++ b/azure/microservice-ecommerce/blueprint.yaml
@@ -47,17 +47,19 @@ spec:
   # ############################################################################
   - name: StorageAccountName
     type: Input
-    prompt: "Enter the Storage Account where Terraform will store its state (see aws/README.md):"
+    prompt: "Enter the Storage Account where Terraform will store its state (see azure/README.md):"
+    description: Can contain only lowercase letters and numbers. Must be between 3 and 24 characters.
     promptIf: ProvisionCluster
+    validate: !expr "regex('^[a-z0-9]{3,24}$', StorageAccountName)"
 
   - name: StorageAccessKey
     type: Input
-    prompt: "Enter the Storage Account key for accessing the storage (see aws/README.md):"
+    prompt: "Enter the Storage Account key for accessing the storage (see azure/README.md):"
     promptIf: ProvisionCluster
 
   - name: StorageContainerName
     type: Input
-    prompt: "Enter the Storage Container name (see aws/README.md):"
+    prompt: "Enter the Storage Container name (see azure/README.md):"
     promptIf: ProvisionCluster
     default: terraform-state
   # ############################################################################

--- a/azure/microservice-ecommerce/terraform-microservice-ecommerce/main.tf
+++ b/azure/microservice-ecommerce/terraform-microservice-ecommerce/main.tf
@@ -12,22 +12,22 @@ resource "azurerm_resource_group" "k8s" {
 }
 
 module "vpc" {
-  source              = "./vpc"
-  name                = "${var.cluster_name}"
-  location            = "${azurerm_resource_group.k8s.location}"
-  resource_group_name = "${azurerm_resource_group.k8s.name}"
+  source                  = "./vpc"
+  name                    = "${var.cluster_name}"
+  resource_group_location = "${azurerm_resource_group.k8s.location}"
+  resource_group          = "${azurerm_resource_group.k8s.name}"
 }
 
 module "aks" {
   source              = "./aks"
-  location            = "${azurerm_resource_group.k8s.location}"
-  resource_group_name = "${azurerm_resource_group.k8s.name}"
-  cluster_name        = "${var.cluster_name}"
-  vm_size             = "${var.vm_size}"
-  node_count          = "${var.node_count}"
-  admin_username      = "${var.admin_username}"
-  client_id           = "${var.client_id}"
-  client_secret       = "${var.client_secret}"
-  dns_prefix          = "${var.dns_prefix}"
-  subnet_id           = "${module.vpc.subnet_id}"
+  resource_group_location = "${azurerm_resource_group.k8s.location}"
+  resource_group          = "${azurerm_resource_group.k8s.name}"
+  cluster_name            = "${var.cluster_name}"
+  vm_size                 = "${var.vm_size}"
+  node_count              = "${var.node_count}"
+  admin_username          = "${var.admin_username}"
+  client_id               = "${var.client_id}"
+  client_secret           = "${var.client_secret}"
+  dns_prefix              = "${var.dns_prefix}"
+  subnet_id               = "${module.vpc.subnet_id}"
 }

--- a/azure/microservice-ecommerce/xebialabs.yaml
+++ b/azure/microservice-ecommerce/xebialabs.yaml
@@ -3,9 +3,9 @@ kind: Import
 metadata:
   imports:
   - xebialabs/xld-microservice-ecommerce-infra-env.yaml
-  - xebialabs/xld-microservice-ecommerce-invoice-application.yaml
-  - xebialabs/xld-microservice-ecommerce-notification-application.yaml
-  - xebialabs/xld-microservice-ecommerce-store-application.yaml
-  - xebialabs/xld-microservice-ecommerce-terraform-application.yaml
+  - xebialabs/xld-microservice-ecommerce-invoice-applications.yaml
+  - xebialabs/xld-microservice-ecommerce-notification-applications.yaml
+  - xebialabs/xld-microservice-ecommerce-store-applications.yaml
+  - xebialabs/xld-microservice-ecommerce-terraform-applications.yaml
   - xebialabs/xlr-microservice-ecommerce-pipeline-ci-cd.yaml
   - xebialabs/xlr-microservice-ecommerce-pipeline-destroy.yaml

--- a/azure/microservice-ecommerce/xebialabs/xld-microservice-ecommerce-infra-env.yaml.tmpl
+++ b/azure/microservice-ecommerce/xebialabs/xld-microservice-ecommerce-infra-env.yaml.tmpl
@@ -38,7 +38,7 @@ spec:
 - name: {{$app}}
   type: core.Directory
   children:
-  - name: azure-aks-{{$clusterName}}
+  - name: {{$clusterName}}-AKSCluster
     type: k8s.Master
     apiServerURL: {{.ClusterEndpoint}}
     skipTLS: true
@@ -47,6 +47,8 @@ spec:
     - name: {{.Namespace | kebabcase}}
       type: k8s.Namespace
       namespaceName: {{.Namespace}}
+      tags:
+      - {{.Namespace}}
 ---
 # Definition of existing AKS Environment
 apiVersion: xl-deploy/v1
@@ -58,6 +60,6 @@ spec:
   - name: azure-aks-{{$app}}
     type: udm.Environment
     members:
-    - Infrastructure/{{$app}}/azure-aks-{{$clusterName}}/{{.Namespace | kebabcase}}
-    - Infrastructure/{{$app}}/azure-aks-{{$clusterName}}
+    - Infrastructure/{{$app}}/{{$clusterName}}-AKSCluster
+    - Infrastructure/{{$app}}/{{$clusterName}}-AKSCluster/{{.Namespace | kebabcase}}
 {{end}}


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
