### PR TITLE
Love 1398 - Fixes needed to deploy gcp cluster

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -116,7 +116,7 @@ gcloud iam service-accounts keys create account.json \
 --iam-account terraform@${TF_ADMIN}.iam.gserviceaccount.com
 ```
 
-> **Note:** Store `account.json` somewhere safe. You'll need it to deploy blueprints to GCP
+> **Note:** Store `account.json` somewhere safe. You'll need it to deploy blueprints to GCP. Your account.json file needs to be put in the generated terraform folder before xl apply can be run.  
 
 Grant the service account permission to view the Admin Project and manage Cloud Storage
 

--- a/gcp/microservice-ecommerce/__test__/test-no-cluster-no-ci-cd.yaml
+++ b/gcp/microservice-ecommerce/__test__/test-no-cluster-no-ci-cd.yaml
@@ -26,3 +26,4 @@ not-expected-files:
 - terraform-microservice-ecommerce/main.tf
 - terraform-microservice-ecommerce/outputs.tf
 - terraform-microservice-ecommerce/variables.tf
+- manifest.yaml

--- a/gcp/microservice-ecommerce/__test__/test-no-cluster-with-ci-cd.yaml
+++ b/gcp/microservice-ecommerce/__test__/test-no-cluster-with-ci-cd.yaml
@@ -26,3 +26,4 @@ not-expected-files:
 - terraform-microservice-ecommerce/main.tf
 - terraform-microservice-ecommerce/outputs.tf
 - terraform-microservice-ecommerce/variables.tf
+- manifest.yaml

--- a/gcp/microservice-ecommerce/__test__/test-with-cluster-no-ci-cd.yaml
+++ b/gcp/microservice-ecommerce/__test__/test-with-cluster-no-ci-cd.yaml
@@ -24,5 +24,7 @@ expected-files:
 - terraform-microservice-ecommerce/variables.tf
 - docker/docker-compose.yml
 - docker/data/configure-xl-devops-platform.yaml
+- manifest.yaml
 not-expected-files:
 - docker/jenkins/jenkins.yaml
+

--- a/gcp/microservice-ecommerce/__test__/test-with-cluster-with-ci-cd.yaml
+++ b/gcp/microservice-ecommerce/__test__/test-with-cluster-with-ci-cd.yaml
@@ -25,3 +25,4 @@ expected-files:
 - docker/docker-compose.yml
 - docker/data/configure-xl-devops-platform.yaml
 - docker/jenkins/jenkins.yaml
+- manifest.yaml

--- a/gcp/microservice-ecommerce/blueprint.yaml
+++ b/gcp/microservice-ecommerce/blueprint.yaml
@@ -106,7 +106,6 @@ spec:
   - path: xebialabs/xld-microservice-ecommerce-infra-env.yaml.tmpl
   - path: xebialabs/xlr-microservice-ecommerce-pipeline-ci-cd.yaml.tmpl
   - path: xebialabs/xlr-microservice-ecommerce-pipeline-destroy.yaml.tmpl
-  - path: manifest.yaml
   # Terraform
   - path: terraform-microservice-ecommerce/gke/main.tf
     writeIf: ProvisionCluster
@@ -129,4 +128,6 @@ spec:
   - path: terraform-microservice-ecommerce/outputs.tf
     writeIf: ProvisionCluster
   - path: terraform-microservice-ecommerce/variables.tf
+    writeIf: ProvisionCluster
+  - path: manifest.yaml
     writeIf: ProvisionCluster

--- a/gcp/microservice-ecommerce/blueprint.yaml
+++ b/gcp/microservice-ecommerce/blueprint.yaml
@@ -106,6 +106,7 @@ spec:
   - path: xebialabs/xld-microservice-ecommerce-infra-env.yaml.tmpl
   - path: xebialabs/xlr-microservice-ecommerce-pipeline-ci-cd.yaml.tmpl
   - path: xebialabs/xlr-microservice-ecommerce-pipeline-destroy.yaml.tmpl
+  - path: manifest.yaml
   # Terraform
   - path: terraform-microservice-ecommerce/gke/main.tf
     writeIf: ProvisionCluster

--- a/gcp/microservice-ecommerce/manifest.yaml
+++ b/gcp/microservice-ecommerce/manifest.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: client-default-rb
+subjects:
+- kind: User
+  name: system:anonymous
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: client-system-rb
+subjects:
+- kind: User
+  name: system:anonymous
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/gcp/microservice-ecommerce/terraform-microservice-ecommerce/gke/main.tf
+++ b/gcp/microservice-ecommerce/terraform-microservice-ecommerce/gke/main.tf
@@ -38,7 +38,7 @@ resource "google_container_cluster" "primary" {
       "https://www.googleapis.com/auth/monitoring",
     ]
 
-    labels {
+    labels = {
       env = "${var.gke_label}"
     }
 

--- a/gcp/microservice-ecommerce/terraform-microservice-ecommerce/main.tf
+++ b/gcp/microservice-ecommerce/terraform-microservice-ecommerce/main.tf
@@ -2,7 +2,7 @@
 
 provider "google" {
   credentials = "${file("account.json")}"
-  version = "~> 2.11"
+  version = "~> 2.5"
   project = "${var.project_id}"
   region  = "${var.region}"
 }

--- a/gcp/microservice-ecommerce/xebialabs/USAGE-microservice-ecommerce.md.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/USAGE-microservice-ecommerce.md.tmpl
@@ -74,7 +74,28 @@ Go to XL Release and click on `{{$app}}` under the 'Design' tab.
     1. Give the Release a name.
     2. Click 'Create'.
     3. Click 'Start Release'.
-
+    4. When step: 'Apply RBAC authentication' is reached follow the steps below:
+        1. Get the cluster name
+         ```plain
+            gcloud container clusters list
+         ```
+         The name will what your provided in the blueprint set up under cluster name with -cluster appended to it
+         2. Get the authentication details
+         ```plain
+            gcloud container clusters get-credentials [cluster_name from 1] --zone [location from 1]
+         ```
+         3. Switch kube context
+         ```shell script
+             kubectl config set-context [cluster_name from 1]     
+         ```
+         4. Deploy manifest.yaml
+         ```shell script
+             kubectl apply -f manifest.yaml
+         ```
+         5. Click the 3 dots on 'Apply RBAC authentication in XL Release'
+         6. Click assign to me
+         7. Click on 'Apply RBAC authentication'
+         8. Click complete
 ## Undeploy from GCP
 
 Go to XL Release and click on `{{$app}}` under the 'Design' tab.

--- a/gcp/microservice-ecommerce/xebialabs/USAGE-microservice-ecommerce.md.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/USAGE-microservice-ecommerce.md.tmpl
@@ -76,26 +76,26 @@ Go to XL Release and click on `{{$app}}` under the 'Design' tab.
     3. Click 'Start Release'.
     4. When step: 'Apply RBAC authentication' is reached follow the steps below:
         1. Get the cluster name
-         ```plain
-            gcloud container clusters list
-         ```
-         The name will what your provided in the blueprint set up under cluster name with -cluster appended to it
-         2. Get the authentication details
-         ```plain
-            gcloud container clusters get-credentials [cluster_name from 1] --zone [location from 1]
-         ```
-         3. Switch kube context
-         ```shell script
-             kubectl config set-context [cluster_name from 1]     
-         ```
-         4. Deploy manifest.yaml
-         ```shell script
-             kubectl apply -f manifest.yaml
-         ```
-         5. Click the 3 dots on 'Apply RBAC authentication in XL Release'
-         6. Click assign to me
-         7. Click on 'Apply RBAC authentication'
-         8. Click complete
+             ```plain
+                gcloud container clusters list
+             ```
+            The name will what your provided in the blueprint set up under cluster name with -cluster appended to it
+        2. Get the authentication details
+             ```plain
+                gcloud container clusters get-credentials [cluster_name from 1] --zone [location from 1]
+             ```
+        3. Switch kube context
+             ```shell script
+                 kubectl config set-context [cluster_name from 1]     
+             ```
+        4. Deploy manifest.yaml
+             ```shell script
+                 kubectl apply -f manifest.yaml
+             ```
+        5. Click the 3 dots on 'Apply RBAC authentication in XL Release'
+        6. Click assign to me
+        7. Click on 'Apply RBAC authentication'
+        8. Click complete
 ## Undeploy from GCP
 
 Go to XL Release and click on `{{$app}}` under the 'Design' tab.

--- a/gcp/microservice-ecommerce/xebialabs/xlr-microservice-ecommerce-pipeline-ci-cd.yaml.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/xlr-microservice-ecommerce-pipeline-ci-cd.yaml.tmpl
@@ -59,8 +59,9 @@ spec:
         deploymentPackage: {{$app}}/GKE-TERRAFORM/{{$app}}-terraform-gke/1.0.0
         deploymentEnvironment: Environments/{{$app}}/gcp-terraform
     # Apply RBAC
-    - name: Apply RBAC authentication
-      type: core.manual
+      - name: Apply RBAC authentication
+        type: xlrelease.Task
+        description: Check back to the USAGE-microservice-ecommerce.md file for more
     {{end}}
     {{if .EnableCICD}}
     - name: Build {{$app}} application

--- a/gcp/microservice-ecommerce/xebialabs/xlr-microservice-ecommerce-pipeline-ci-cd.yaml.tmpl
+++ b/gcp/microservice-ecommerce/xebialabs/xlr-microservice-ecommerce-pipeline-ci-cd.yaml.tmpl
@@ -58,6 +58,9 @@ spec:
         server: XL Deploy
         deploymentPackage: {{$app}}/GKE-TERRAFORM/{{$app}}-terraform-gke/1.0.0
         deploymentEnvironment: Environments/{{$app}}/gcp-terraform
+    # Apply RBAC
+    - name: Apply RBAC authentication
+      type: core.manual
     {{end}}
     {{if .EnableCICD}}
     - name: Build {{$app}} application


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [x] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
