### PR TITLE
LOVE-1340 Added notes for secrets.xlvals and referred to the dictionaries-and-secret-stores showcase

### DIFF
--- a/aws/basic-eks-cluster/README.md
+++ b/aws/basic-eks-cluster/README.md
@@ -19,6 +19,10 @@ If you're new to XebiaLabs blueprints, check out:
 * AWS Access Key and Secret Key for an account that can deploy the application
 * See the AWS [README.md](https://github.com/xebialabs/blueprints/blob/master/aws/README.md) for instructions on how to set this up
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/aws/basic-lambda/README.md
+++ b/aws/basic-lambda/README.md
@@ -19,6 +19,10 @@ If you're new to XebiaLabs blueprints, check out:
 * AWS Access Key and Secret Key for an account that can deploy the application
 * See the AWS [README.md](https://github.com/xebialabs/blueprints/blob/master/aws/README.md) for instructions on how to set this up
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/aws/datalake/README.md
+++ b/aws/datalake/README.md
@@ -19,6 +19,10 @@ If you're new to XebiaLabs blueprints, check out:
 * AWS Access Key and Secret Key for an account that can deploy the application
 * Email address where Data Lake administrator credentials can be sent
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/aws/elastic-beanstalk/README.md
+++ b/aws/elastic-beanstalk/README.md
@@ -16,6 +16,10 @@ If you're new to XebiaLabs blueprints, check out:
 * XebiaLabs Release Orchestration and Deployment Automation up and running
 * AWS Access Key and Secret Key for an account that can deploy the application
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/aws/intermediate-eks-cluster/README.md
+++ b/aws/intermediate-eks-cluster/README.md
@@ -18,6 +18,10 @@ If you're new to XebiaLabs blueprints, check out:
 * XebiaLabs Release Orchestration and Deployment Automation up and running
 * AWS Access Key and Secret Key for an account that can deploy the application
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/aws/microservice-ecommerce/README.md
+++ b/aws/microservice-ecommerce/README.md
@@ -26,6 +26,10 @@ If you're new to XebiaLabs blueprints, check out:
 
 > For more detailed instructions, see [Deploy an app to AWS using a blueprint](https://docs.xebialabs.com/v.9.0/xl-release/how-to/deploy-to-aws-using-blueprints)
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in **the forked `e-commerce-microservice` directory of the repository you just cloned** and select:

--- a/aws/monolith-terraform/README.md
+++ b/aws/monolith-terraform/README.md
@@ -18,6 +18,10 @@ If you're new to XebiaLabs blueprints, check out:
 * XebiaLabs Release Orchestration and Deployment Automation up and running
 * AWS Access Key and Secret Key for an account that can deploy the application
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/aws/monolith/README.md
+++ b/aws/monolith/README.md
@@ -18,6 +18,10 @@ If you're new to XebiaLabs blueprints, check out:
 * XebiaLabs Release Orchestration and Deployment Automation up and running
 * AWS Access Key and Secret Key for an account that can deploy the application
 
+## Security warning
+
+This blueprint will store your AWS Access Key and Secret Key in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/azure/app-service-docker-app/README.md
+++ b/azure/app-service-docker-app/README.md
@@ -19,6 +19,10 @@ If you're new to XebiaLabs blueprints, check out:
 * Azure credentials that allow creating the infrastructure
 * See the Azure [README.md](https://github.com/xebialabs/blueprints/blob/master/azure/README.md) for instruction on how to set this up
 
+## Security warning
+
+This blueprint will store your Azure credentials as well as the MySQL password in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/azure/basic-aks-cluster/README.md
+++ b/azure/basic-aks-cluster/README.md
@@ -19,6 +19,8 @@ If you're new to XebiaLabs blueprints, check out:
 * Azure credentials that allow creating the infrastructure
 * See the Azure [README.md](https://github.com/xebialabs/blueprints/blob/master/azure/README.md) for instruction on how to set this up
 
+This blueprint will store your Azure credentials in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/azure/basic-arm-template/README.md
+++ b/azure/basic-arm-template/README.md
@@ -18,6 +18,10 @@ If you're new to XebiaLabs blueprints, check out:
 * XebiaLabs Release Orchestration and Deployment Automation up and running
 * Azure credentials that allow creating the infrastructure
 
+## Security warning
+
+This blueprint will store your Azure credentials as well as the admin password in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/azure/microservice-ecommerce/README.md
+++ b/azure/microservice-ecommerce/README.md
@@ -31,6 +31,10 @@ If you're new to XebiaLabs blueprints, check out:
 > For more detailed instructions, see [Deploy an app to AWS using a blueprint](https://docs.xebialabs.com/v.9.0/xl-release/how-to/deploy-to-aws-using-blueprints)
 > **Note:** This blueprint uses the same branch as the Google GKE example
 
+## Security warning
+
+This blueprint will store your Azure credentials as well as the cluster password token and the store admin password in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in **the forked `e-commerce-microservice` directory of the repository you just cloned** and select:

--- a/blueprint-skeleton/README.md
+++ b/blueprint-skeleton/README.md
@@ -2,6 +2,10 @@
 
 This blueprint generates a blueprint skeleton of directories and files in order for you to create your own blueprint.
 
+## Security warning
+
+Be careful when including an secret inputs. These are stored in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/devsecops/security-scanning/README.md
+++ b/devsecops/security-scanning/README.md
@@ -16,6 +16,10 @@ If you're new to XebiaLabs blueprints, check out:
 * XebiaLabs Release Orchestration up and running
 * Access to one or more security testing tool(s)
 
+## Security warning
+
+This blueprint will store various passwords in plain text in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/gcp/basic-gke-cluster/README.md
+++ b/gcp/basic-gke-cluster/README.md
@@ -18,6 +18,10 @@ If you're new to XebiaLabs blueprints, check out:
 * XebiaLabs Deployment Automation up and running
 * Access to a Google Cloud Platform (GCP) account where you can deploy the GKE Cluster
 
+## Security warning
+
+This blueprint will store the Kubernetes master password in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:

--- a/gcp/microservice-ecommerce/README.md
+++ b/gcp/microservice-ecommerce/README.md
@@ -30,6 +30,10 @@ If you're new to XebiaLabs blueprints, check out:
 
 > For more detailed instructions, see [Deploy an app to AWS using a blueprint](https://docs.xebialabs.com/v.9.0/xl-release/how-to/deploy-to-aws-using-blueprints)
 
+## Security warning
+
+This blueprint will store the Kubernetes master password in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in **the forked `e-commerce-microservice` directory of the repository you just cloned** and select:

--- a/kubernetes/environment/README.md
+++ b/kubernetes/environment/README.md
@@ -15,6 +15,10 @@ If you're new to XebiaLabs blueprints, check out:
 
 * XebiaLabs Deployment Automation up and running
 
+## Security warning
+
+This blueprint will store the Kubernetes client certificate and private key in a file called `xebialabs/secrets.xlvals`. This is not production-level secure. If you wish to use a more secure method for dealing with secrets and passwords, refer to the `showcases/dictionaries-and-secret-stores` blueprint for a demonstration that uses CyberArk Conjur or HashiCorp Vault to better store and handle secrets.
+
 ## Usage
 
 To use this blueprint, run `xl blueprint` in an empty directory and select:


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] If the blueprint depends on external products that can be started as a Docker container, the blueprint generates a `docker/docker-compose.yml` file so that it can be tested without having to manually install those products. Do not use this Docker Compose file to start XL Deploy, XL Release, Docker or Kubernetes.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
